### PR TITLE
update version - in preparation for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XCALibre"
 uuid = "cf91e36b-bd94-493a-8848-32508a10963c"
 authors = ["Humberto <h.medina@aerofluids.org>"]
-version = "0.4.0-DEV"
+version = "0.4.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Update package version to 0.4.0 due to minor API breaking change - removal of `limit_gradient` keyword arguement in solver call. Now, limiters are selected via `schemes` using the `limiter` keyword argument