### PR TITLE
HP/DESAdjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 The format used for this `changelog` is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Notice that until the package reaches version `v1.0.0` minor releases are likely to be `breaking`. Starting from version `v0.3.1` breaking changes will be recorded here. 
 
+## Version [v0.4.1] - 2025-xx-xx
+
+### Added
+* No new functionality has been added
+
+### Fixed
+* No fixes included
+
+### Changed
+* In preparation for implementation of hybrid models e.g. DES, the signature of the `turbulence!` function has been updated to use the `AbstractTurbulenceModel` [#39](@ref)
+
+### Breaking
+* No breaking changes
+
+### Deprecated
+* No functions deprecated
+
+### Removed
+* No functionality has been removed
+
 ## Version [v0.4.0] - 2025-02-17
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XCALibre"
 uuid = "cf91e36b-bd94-493a-8848-32508a10963c"
 authors = ["Humberto <h.medina@aerofluids.org>"]
-version = "0.4.0"
+version = "0.4.1-DEV"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/ModelPhysics/Turbulence/LES_Smagorinsky.jl
+++ b/src/ModelPhysics/Turbulence/LES_Smagorinsky.jl
@@ -96,7 +96,7 @@ Run turbulence model transport equations.
 """
 function turbulence!(
     les::SmagorinskyModel{E1,E2}, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time, config
-    ) where {T,F,M,Tu,E,D,BI,E1,E2}
+    ) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI,E1,E2}
 
     mesh = model.domain
     

--- a/src/ModelPhysics/Turbulence/LES_Smagorinsky.jl
+++ b/src/ModelPhysics/Turbulence/LES_Smagorinsky.jl
@@ -96,7 +96,7 @@ Run turbulence model transport equations.
 """
 function turbulence!(
     les::SmagorinskyModel{E1,E2}, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time, config
-    ) where {T,F,M,Tu<:Smagorinsky,E,D,BI,E1,E2}
+    ) where {T,F,M,Tu,E,D,BI,E1,E2}
 
     mesh = model.domain
     

--- a/src/ModelPhysics/Turbulence/RANS_kOmega.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmega.jl
@@ -147,7 +147,7 @@ Run turbulence model transport equations.
 """
 function turbulence!(
     rans::KOmegaModel{E1,E2,S1}, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time, config
-    ) where {T,F,M,Tu,E,D,BI,E1,E2,S1}
+    ) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI,E1,E2,S1}
 
     mesh = model.domain
     

--- a/src/ModelPhysics/Turbulence/RANS_kOmega.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmega.jl
@@ -147,7 +147,7 @@ Run turbulence model transport equations.
 """
 function turbulence!(
     rans::KOmegaModel{E1,E2,S1}, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time, config
-    ) where {T,F,M,Tu<:KOmega,E,D,BI,E1,E2,S1}
+    ) where {T,F,M,Tu,E,D,BI,E1,E2,S1}
 
     mesh = model.domain
     

--- a/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
@@ -282,7 +282,7 @@ Run turbulence model transport equations.
 """
 function turbulence!(
     rans::KOmegaLKEModel, model::Physics{T,F,M,Turb,E,D,BI}, S, prev, time, config
-    ) where {T,F,M,Turb<:KOmegaLKE,E,D,BI}
+    ) where {T,F,M,Turb,E,D,BI}
     mesh = model.domain
     (; momentum, turbulence) = model
     U = momentum.U

--- a/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
@@ -282,7 +282,7 @@ Run turbulence model transport equations.
 """
 function turbulence!(
     rans::KOmegaLKEModel, model::Physics{T,F,M,Turb,E,D,BI}, S, prev, time, config
-    ) where {T,F,M,Turb,E,D,BI}
+    ) where {T,F,M,Turb<:AbstractTurbulenceModel,E,D,BI}
     mesh = model.domain
     (; momentum, turbulence) = model
     U = momentum.U

--- a/src/ModelPhysics/Turbulence/RANS_laminar.jl
+++ b/src/ModelPhysics/Turbulence/RANS_laminar.jl
@@ -71,13 +71,13 @@ Run turbulence model transport equations.
 
 """
 function turbulence!(rans::LaminarModel, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time,config
-    ) where {T,F,M,Tu,E,D,BI}
+    ) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI}
     nothing
 end
 
 function turbulence!(
     rans::LaminarModel, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time, config
-    ) where {T,F<:AbstractCompressible,M,Tu,E,D,BI}
+    ) where {T,F<:AbstractCompressible,M,Tu<:AbstractTurbulenceModel,E,D,BI}
     (; U, Uf, gradU) = S
     grad!(gradU, Uf, U, U.BCs, time, config)
     limit_gradient!(config.schemes.U.limiter, gradU, U, config)

--- a/src/ModelPhysics/Turbulence/RANS_laminar.jl
+++ b/src/ModelPhysics/Turbulence/RANS_laminar.jl
@@ -71,13 +71,13 @@ Run turbulence model transport equations.
 
 """
 function turbulence!(rans::LaminarModel, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time,config
-    ) where {T,F,M,Tu<:Laminar,E,D,BI}
+    ) where {T,F,M,Tu,E,D,BI}
     nothing
 end
 
 function turbulence!(
     rans::LaminarModel, model::Physics{T,F,M,Tu,E,D,BI}, S, prev, time, config
-    ) where {T,F<:AbstractCompressible,M,Tu<:Laminar,E,D,BI}
+    ) where {T,F<:AbstractCompressible,M,Tu,E,D,BI}
     (; U, Uf, gradU) = S
     grad!(gradU, Uf, U, U.BCs, time, config)
     limit_gradient!(config.schemes.U.limiter, gradU, U, config)


### PR DESCRIPTION
In preparation for the implementation of hybrid turbulence models e.g. DES, this PR removes unnecessary type restraints in the argument signature of the `turbulence!` function, instead of specific turbulence model implementations the abstract type `AbstractTurbulenceModel` is now used. This does not affect functionality of existing implementations.