### PR TITLE
Add nut access function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * No fixes have been added
 
 ### Changed
-* No changes have been made
+* In preparation for implementation of hybrid models e.g. DES, the `turbulence!` function now uses `_nut_access` to acces eddy viscosity fields, rather than taking them directly from the model
 
 ### Breaking
 * No breaking changes

--- a/src/ModelPhysics/Turbulence/DES_Menter.jl
+++ b/src/ModelPhysics/Turbulence/DES_Menter.jl
@@ -1,0 +1,4 @@
+export MenterF1
+
+struct MenterF1 #This is a dummy struct to allow the νₜ access function to be written ready for DES implementation
+end

--- a/src/ModelPhysics/Turbulence/DES_Menter.jl
+++ b/src/ModelPhysics/Turbulence/DES_Menter.jl
@@ -1,4 +1,0 @@
-export MenterF1
-
-struct MenterF1 #This is a dummy struct to allow the νₜ access function to be written ready for DES implementation
-end

--- a/src/ModelPhysics/Turbulence/LES_Smagorinsky.jl
+++ b/src/ModelPhysics/Turbulence/LES_Smagorinsky.jl
@@ -100,7 +100,8 @@ function turbulence!(
 
     mesh = model.domain
     
-    (; nut, nutf, coeff) = model.turbulence
+    (; coeff) = model.turbulence
+    nut,nutf = _nut_access(model,les)
     (; U, Uf, gradU) = S
     (; Δ, magS) = les
 

--- a/src/ModelPhysics/Turbulence/RANS_kOmega.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmega.jl
@@ -152,7 +152,8 @@ function turbulence!(
     mesh = model.domain
     
     (; rho, rhof, nu, nuf) = model.fluid
-    (;k, omega, nut, kf, omegaf, nutf, coeffs) = model.turbulence
+    (;k, omega, kf, omegaf, coeffs) = model.turbulence
+    nut,nutf = _nut_access(model,rans)
     (; U, Uf, gradU) = S
     (;k_eqn, ω_eqn, state) = rans
     (; solvers, runtime) = config

--- a/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
@@ -286,7 +286,8 @@ function turbulence!(
     mesh = model.domain
     (; momentum, turbulence) = model
     U = momentum.U
-    (; k, omega, kl, nut, y, kf, omegaf, klf, nutf, coeffs, Tu) = turbulence
+    (; k, omega, kl, y, kf, omegaf, klf, coeffs, Tu) = turbulence
+    nut,nutf = _nut_access(model,rans)
     (; nu) = model.fluid
     (; U, Uf, gradU) = S
     

--- a/src/ModelPhysics/Turbulence/Turbulence.jl
+++ b/src/ModelPhysics/Turbulence/Turbulence.jl
@@ -28,6 +28,9 @@ include("RANS_kOmegaLKE.jl")
 include("LES_functions.jl")
 include("LES_Smagorinsky.jl")
 
+#Functions
+include("turbulence_functions.jl")
+
 export initialise, turbulence!, model2vtk
 
 # end # end module

--- a/src/ModelPhysics/Turbulence/Turbulence.jl
+++ b/src/ModelPhysics/Turbulence/Turbulence.jl
@@ -28,9 +28,6 @@ include("RANS_kOmegaLKE.jl")
 include("LES_functions.jl")
 include("LES_Smagorinsky.jl")
 
-# DES models
-include("DES_Menter.jl")
-
 #Functions
 include("turbulence_functions.jl")
 

--- a/src/ModelPhysics/Turbulence/Turbulence.jl
+++ b/src/ModelPhysics/Turbulence/Turbulence.jl
@@ -28,6 +28,9 @@ include("RANS_kOmegaLKE.jl")
 include("LES_functions.jl")
 include("LES_Smagorinsky.jl")
 
+# DES models
+include("DES_Menter.jl")
+
 #Functions
 include("turbulence_functions.jl")
 

--- a/src/ModelPhysics/Turbulence/turbulence_functions.jl
+++ b/src/ModelPhysics/Turbulence/turbulence_functions.jl
@@ -1,8 +1,5 @@
 export _nut_access
 
-struct MenterF1 #This is a dummy struct to allow the νₜ access function to be written ready for DES implementation
-end
-
 """
     _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI}
 

--- a/src/ModelPhysics/Turbulence/turbulence_functions.jl
+++ b/src/ModelPhysics/Turbulence/turbulence_functions.jl
@@ -25,7 +25,7 @@ end
 
 #Version for DES models
 function _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:MenterF1,E,D,BI}
-    if (turb::KOmegaModel) || (turb::KOmegaLKEModel) || (turb::LaminarModel)
+    if (turb::KOmegaModel) || (turb::KOmegaLKEModel)
         (;nut,nutf) = model.turbulence.rans
     elseif (turb::SmagorinskyModel)
         (;nut,nutf) = model.turbulence.les

--- a/src/ModelPhysics/Turbulence/turbulence_functions.jl
+++ b/src/ModelPhysics/Turbulence/turbulence_functions.jl
@@ -1,15 +1,34 @@
 export _nut_access
 
-struct MenterF1
+struct MenterF1 #This is a dummy struct to allow the νₜ access function to be written ready for DES implementation
 end
 
+"""
+    _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI}
+
+Access νₜ field from model.
+
+### Input
+- `model`  -- Physics model defined by user.
+- `turb` -- Turbulence model to be used
+###
+
+### Output
+- `nut`-- Eddy Viscosity ScalarField 
+- `nutf`-- Eddy Viscosity FaceScalarField
+###
+"""
 function _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI}
-    println("turbulence model is of type: ", typeof(turb))
     (;nut,nutf) = model.turbulence
     return (nut,nutf)
 end
 
+#Version for DES models
 function _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:MenterF1,E,D,BI}
-    
-
+    if (turb::KOmegaModel) || (turb::KOmegaLKEModel) || (turb::LaminarModel)
+        (;nut,nutf) = model.turbulence.rans
+    elseif (turb::SmagorinskyModel)
+        (;nut,nutf) = model.turbulence.les
+    end
+    return (nut,nutf)
 end

--- a/src/ModelPhysics/Turbulence/turbulence_functions.jl
+++ b/src/ModelPhysics/Turbulence/turbulence_functions.jl
@@ -1,0 +1,15 @@
+export _nut_access
+
+struct MenterF1
+end
+
+function _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI}
+    println("turbulence model is of type: ", typeof(turb))
+    (;nut,nutf) = model.turbulence
+    return (nut,nutf)
+end
+
+function _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:MenterF1,E,D,BI}
+    
+
+end

--- a/src/ModelPhysics/Turbulence/turbulence_functions.jl
+++ b/src/ModelPhysics/Turbulence/turbulence_functions.jl
@@ -1,5 +1,8 @@
 export _nut_access
 
+struct MenterF1 #This is a dummy struct to allow the νₜ access function to be written ready for DES implementation
+end
+
 """
     _nut_access(model::Physics{T,F,M,Tu,E,D,BI},turb) where {T,F,M,Tu<:AbstractTurbulenceModel,E,D,BI}
 


### PR DESCRIPTION
This PR changes how the `turbulence!` function accesses the eddy viscosity fields, now using `_nut_access` which takes inputs of a `model::physics` and turbulence model such as `KOmegaModel`. This is in preparation for the addition of blending models like DES.