### PR TITLE
Fix wall distance calculation implementaiton 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 The format used for this `changelog` is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Notice that until the package reaches version `v1.0.0` minor releases are likely to be `breaking`. Starting from version `v0.3.1` breaking changes will be recorded here. 
 
+## Version [v0.4.3] - 2025-XX-XX
+
+### Added
+* No functionality added
+
+### Fixed
+* Fixed the implementation for the calculation of the wall distance to work on GPUs [#49](@ref)
+
+### Changed
+* In the calculation of wall function properties the user-provided wall velocity is now used, instead of hard-coded to no-slip (`Wall` boundary is still hard-coded until a solution for access the `terms` object on the GPU is found) [#49](@ref)
+
+### Breaking
+* No breaking changes
+
+### Deprecated
+* No functions deprecated
+
+### Removed
+* No functionality has been removed
+
 ## Version [v0.4.2] - 2025-04-02
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XCALibre"
 uuid = "cf91e36b-bd94-493a-8848-32508a10963c"
 authors = ["Humberto <h.medina@aerofluids.org>"]
-version = "0.4.2"
+version = "0.4.3-DEV"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Calculate/Calculate_4_wall_distance.jl
+++ b/src/Calculate/Calculate_4_wall_distance.jl
@@ -32,7 +32,7 @@ function wall_distance!(model, config)
     grad!(phiGrad, phif, phi, phi.BCs, zero(TF), config) # assuming time=0
 
     n_cells = length(mesh.cells)
-    prev = zeros(TF, n_cells)
+    prev = similar(phi.values)
     # R_phi = ones(TF, iterations)
 
     iterations = 1000

--- a/src/Discretise/boundary_conditions/wall.jl
+++ b/src/Discretise/boundary_conditions/wall.jl
@@ -42,8 +42,8 @@ end
     flux = J*area/delta
     ap = term.sign[1]*(-flux)
     
-    # vb = SVector{3}(0.0,0.0,0.0) # do not hard-code in next version
-    vb = phi.BCs[bc.ID].value # there is room to simplify this - pass U.BCs not U.x.BCs
+    vb = SVector{3}(0.0,0.0,0.0) # do not hard-code in next version
+    # vb = phi.BCs[bc.ID].value # this doesn't work on GPU - structure needs sorting!
     vc = phi[cellID]
     vc_n = (vc⋅normal)*normal
     vb_n = (vb⋅normal)*normal

--- a/src/Discretise/boundary_conditions/wall.jl
+++ b/src/Discretise/boundary_conditions/wall.jl
@@ -42,7 +42,8 @@ end
     flux = J*area/delta
     ap = term.sign[1]*(-flux)
     
-    vb = SVector{3}(0.0,0.0,0.0) # do not hard-code in next version
+    # vb = SVector{3}(0.0,0.0,0.0) # do not hard-code in next version
+    vb = phi.BCs[bc.ID].value # there is room to simplify this - pass U.BCs not U.x.BCs
     vc = phi[cellID]
     vc_n = (vc⋅normal)*normal
     vb_n = (vb⋅normal)*normal

--- a/src/ModelPhysics/Turbulence/RANS_functions.jl
+++ b/src/ModelPhysics/Turbulence/RANS_functions.jl
@@ -284,7 +284,8 @@ end
     (; U) = momentum
     (; k, nut) = turbulence
 
-    Uw = SVector{3}(0.0,0.0,0.0)
+    # Uw = SVector{3}(0.0,0.0,0.0)
+    Uw = momentum.U.BCs[BC.ID].value
     cID = boundary_cellsID[fID]
     face = faces[fID]
     nuc = nu[cID]

--- a/src/ModelPhysics/Turbulence/RANS_functions.jl
+++ b/src/ModelPhysics/Turbulence/RANS_functions.jl
@@ -285,7 +285,7 @@ end
     (; k, nut) = turbulence
 
     # Uw = SVector{3}(0.0,0.0,0.0)
-    Uw = momentum.U.BCs[BC.ID].value
+    Uw = U.BCs[BC.ID].value
     cID = boundary_cellsID[fID]
     face = faces[fID]
     nuc = nu[cID]

--- a/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
@@ -96,8 +96,9 @@ end
     # Allocate wall distance "y" and setup boundary conditions
     y = ScalarField(mesh)
     walls = rans.args.walls
+    boundaries_cpu = get_boundaries(mesh.boundaries)
     BCs = []
-    for boundary ∈ mesh.boundaries
+    for boundary ∈ boundaries_cpu
         for namedwall ∈ walls
             if boundary.name == namedwall
                 push!(BCs, Dirichlet(boundary.name, 0.0))


### PR DESCRIPTION
This PR introduces the following:
- Fix the wall distance calculation implementation to work on GPUs, a copy of the `boundary` mesh information is needed on the CPU to avoid scalar operations
- Wall functions use user-provided velocity in their calculation, previously a no-slip condition was hard-coded
- project version tag as DEV
- changes on this PR have been added to the changelog