### PR TITLE
Merge pull request #53 from Hm/expose model to update boundary func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * In the calculation of wall function properties the user-provided wall velocity is now used, instead of hard-coded to no-slip (`Wall` boundary is still hard-coded until a solution for access the `terms` object on the GPU is found) [#49](@ref)
+* In preparation for the addition of a neural network-based wall functions to correct the `Pk` and `nutw` terms at the wall, the `correct_eddy_viscosity` has been modified, now using multiple dispatch as a way to inject user boundary code [#53](@ref)
+* `update_user_boundary` function has been updated, to expose the `ModelEquation` type to it, providing the framework needed for the implementation of the neural network-based wall functions [#53](@ref)
 
 ### Breaking
 * No breaking changes

--- a/docs/src/examples/04_2d-inflow-using-Flux.md
+++ b/docs/src/examples/04_2d-inflow-using-Flux.md
@@ -148,7 +148,7 @@ The third step is to define a new method for the `update_user_boundary!` functio
 ```@example flux
 
 XCALibre.Discretise.update_user_boundary!(
-    BC::DirichletFunction{I,V}, faces, cells, facesID_range, time, config
+    BC::DirichletFunction{I,V}, eqnModel, component, faces, cells, facesID_range, time, config
     ) where{I,V<:Inflow} = 
 begin
 
@@ -157,14 +157,14 @@ begin
 
     kernel_range = length(facesID_range)
     kernel! = _update_user_boundary!(backend, workgroup, kernel_range)
-    kernel!(BC, faces, cells, facesID_range, time, ndrange=kernel_range)
+    kernel!(BC, eqnModel, component, faces, cells, facesID_range, time, ndrange=kernel_range)
     KernelAbstractions.synchronize(backend)
 
     (; output, input, U, network, xdir) = BC.value
     output .= U.*network(input).*xdir # convert to vector
 end
 
-@kernel function _update_user_boundary!(BC, faces, cells, facesID_range, time)
+@kernel function _update_user_boundary!(BC, eqnModel, component, faces, cells, facesID_range, time)
     i = @index(Global)
     startID = facesID_range[1]
     fID = i + startID - 1

--- a/examples/2D_BFS_neural_network.jl
+++ b/examples/2D_BFS_neural_network.jl
@@ -58,7 +58,7 @@ Adapt.@adapt_structure Inflow
 # import XCALibre.Discretise: update_boundary!
 
 XCALibre.Discretise.update_user_boundary!(
-    BC::DirichletFunction{I,V}, faces, cells, facesID_range, time, config) where{I,V<:Inflow}= begin
+    BC::DirichletFunction{I,V}, eqnModel, component, faces, cells, facesID_range, time, config) where{I,V<:Inflow}= begin
     # if time > 1 # for this to work need to add time to steady solvers! # to do
     #     return nothing
     # end
@@ -68,12 +68,12 @@ XCALibre.Discretise.update_user_boundary!(
 
     kernel_range = length(facesID_range)
     kernel! = _update_user_boundary!(backend, workgroup, kernel_range)
-    kernel!(BC, faces, cells, facesID_range, time, ndrange=kernel_range)
+    kernel!(BC, eqnModel, component, faces, cells, facesID_range, time, ndrange=kernel_range)
     # KernelAbstractions.synchronize(backend)
     BC.value.output .= BC.value.network(BC.value.input).*BC.value.xdir
 end
 
-@kernel function _update_user_boundary!(BC, faces, cells, facesID_range, time)
+@kernel function _update_user_boundary!(BC, eqnModel, component, faces, cells, facesID_range, time)
     i = @index(Global)
     startID = facesID_range[1]
     fID = i + startID - 1

--- a/examples/2D_flatplate_highRe.jl
+++ b/examples/2D_flatplate_highRe.jl
@@ -1,6 +1,6 @@
 # using Plots
 using XCALibre
-# using CUDA
+using CUDA
 
 grids_dir = pkgdir(XCALibre, "examples/0_GRIDS")
 grid = "flatplate_2D_highRe.unv"
@@ -10,8 +10,8 @@ mesh = UNV2D_mesh(mesh_file, scale=0.001)
 
 backend = CPU(); # activate_multithread(backend)
 mesh_dev = mesh; workgroup = 1024
-# backend = CUDABackend()
-# mesh_dev = adapt(backend, mesh); workgroup= 32
+backend = CUDABackend()
+mesh_dev = adapt(backend, mesh); workgroup= 32
 
 velocity = [10, 0.0, 0.0]
 nu = 1e-5

--- a/src/Discretise/Discretise_5_apply_bcs.jl
+++ b/src/Discretise/Discretise_5_apply_bcs.jl
@@ -2,13 +2,13 @@ export apply_boundary_conditions!
 export get_boundaries
 
 
-apply_boundary_conditions!(eqn, BCs, component, time, config) = begin
-    _apply_boundary_conditions!(eqn.model, BCs, eqn, component, time, config)
+apply_boundary_conditions!(eqnModel, BCs, component, time, config) = begin
+    _apply_boundary_conditions!(eqnModel.model, BCs, eqnModel, component, time, config)
 end
 
 # Apply Boundaries Function
 function _apply_boundary_conditions!(
-    model::Model{TN,SN,T,S}, BCs::B, eqn, component, time, config) where {TN,SN,T,S,B}
+    model::Model{TN,SN,T,S}, BCs::B, eqnModel, component, time, config) where {TN,SN,T,S,B}
     nTerms = length(model.terms)
 
     # backend = _get_backend(mesh)
@@ -17,8 +17,8 @@ function _apply_boundary_conditions!(
 
     # Retriecve variables for function
     mesh = model.terms[1].phi.mesh
-    A = _A(eqn)
-    b = _b(eqn, component)
+    A = _A(eqnModel)
+    b = _b(eqnModel, component)
 
     # Deconstruct mesh to required fields
     (; faces, cells, boundary_cellsID) = mesh
@@ -41,7 +41,10 @@ function _apply_boundary_conditions!(
         start_ID = facesID_range[1]
 
         # update user defined boundary storage (if needed)
-        update_user_boundary!(BC, faces, cells, facesID_range, time, config)
+        # update_user_boundary!(BC, faces, cells, facesID_range, time, config)
+        #= The `model` passed here is defined in ModelFramework_0_types.jl line 87. It has two properties: terms and sources which define the equation being solved =#
+        update_user_boundary!(
+            BC, eqnModel, component, faces, cells, facesID_range, time, config)
         
         # Execute apply boundary conditions kernel
         kernel_range = length(facesID_range)
@@ -57,7 +60,7 @@ function _apply_boundary_conditions!(
 end
 
 update_user_boundary!(
-    BC::AbstractBoundary, faces, cells, facesID_range, time, config) = nothing
+    BC::AbstractBoundary, eqnModel, component, faces, cells, facesID_range, time, config) = nothing
 
 # Function to prevent redundant CPU copy
 

--- a/src/Discretise/boundary_conditions/dirichletFunction_interpolation.jl
+++ b/src/Discretise/boundary_conditions/dirichletFunction_interpolation.jl
@@ -42,7 +42,8 @@ function adjust_boundary!(
 
     if !BC.value.steady
         config = (;hardware=(;backend=backend, workgroup=workgroup)) # temp solution
-        update_user_boundary!(BC, faces, cells, facesID_range, time, config)
+        update_user_boundary!(
+            BC, eqnModel, component, faces, cells, facesID_range, time, config)
     end
 
     kernel! = adjust_boundary_dirichletFunction_scalar!(backend, workgroup)
@@ -61,7 +62,8 @@ function adjust_boundary!(
 
     if !BC.value.steady
         config = (;hardware=(;backend=backend, workgroup=workgroup)) # temp solution
-        update_user_boundary!(BC, faces, cells, facesID_range, time, config)
+        update_user_boundary!(
+            BC, eqnModel, component, faces, cells, facesID_range, time, config)
     end
 
     kernel! = adjust_boundary_dirichletFunction_vector!(backend, workgroup)

--- a/src/ModelPhysics/Turbulence/RANS_functions.jl
+++ b/src/ModelPhysics/Turbulence/RANS_functions.jl
@@ -303,44 +303,15 @@ end
     end
 end
 
-# @generated correct_eddy_viscosity!(νtf, nutBCs, model, config) = begin
-#     BCs = nutBCs.parameters
-#     func_calls = Expr[]
-#     for i ∈ eachindex(BCs)
-#         BC = BCs[i]
-#         if BC <: NutWallFunction
-#             call = quote
-#                 correct_nut_wall!(BC, νtf, nutBCs[$i], model, config)
-#             end
-#             push!(func_calls, call)
-#         end
-#     end
-#     quote
-#     $(func_calls...)
-#     nothing
-#     end 
-# end
-
 @generated function correct_eddy_viscosity!(νtf, nutBCs, model, config)
-    # BCs = nutBCs.parameters
     unpacked_BCs = []
     for i ∈ 1:length(nutBCs.parameters)
-        # BC = BCs[i]
         unpack = quote
             correct_nut_wall!(νtf, nutBCs[$i], model, config)
         end
         push!(unpacked_BCs, unpack)
     end
     quote
-    # (; mesh) = phif
-    # (; boundary_cellsID, boundaries) = mesh 
-    # (; hardware) = config
-    # (; backend, workgroup) = hardware
-    # # b_cpu = Array{eltype(boundaries)}(undef, length(boundaries))
-    # # copyto!(b_cpu, boundaries)
-    # b_cpu = to_cpu(boundaries)
-
-    # backend = _get_backend(mesh)
     $(unpacked_BCs...) 
     end
 end

--- a/src/ModelPhysics/Turbulence/RANS_functions.jl
+++ b/src/ModelPhysics/Turbulence/RANS_functions.jl
@@ -322,10 +322,12 @@ end
 # end
 
 @generated function correct_eddy_viscosity!(νtf, nutBCs, model, config)
+    # BCs = nutBCs.parameters
     unpacked_BCs = []
     for i ∈ 1:length(nutBCs.parameters)
+        # BC = BCs[i]
         unpack = quote
-            correct_nut_wall!(BC, νtf, nutBCs[$i], model, config)
+            correct_nut_wall!(νtf, nutBCs[$i], model, config)
         end
         push!(unpacked_BCs, unpack)
     end
@@ -343,9 +345,9 @@ end
     end
 end
 
-correct_nut_wall!(BC, νtf, BC, model, config) = nothing
+correct_nut_wall!(nutf, BC, model, config) = nothing
 
-function correct_nut_wall!(BC::NutWallFunction, νtf, BC, model, config)
+function correct_nut_wall!(νtf, BC::NutWallFunction, model, config)
     # backend = _get_backend(mesh)
     (; hardware) = config
     (; backend, workgroup) = hardware

--- a/src/ModelPhysics/Turbulence/RANS_functions.jl
+++ b/src/ModelPhysics/Turbulence/RANS_functions.jl
@@ -303,25 +303,49 @@ end
     end
 end
 
-@generated correct_eddy_viscosity!(νtf, nutBCs, model, config) = begin
-    BCs = nutBCs.parameters
-    func_calls = Expr[]
-    for i ∈ eachindex(BCs)
-        BC = BCs[i]
-        if BC <: NutWallFunction
-            call = quote
-                correct_nut_wall!(νtf, nutBCs[$i], model, config)
-            end
-            push!(func_calls, call)
+# @generated correct_eddy_viscosity!(νtf, nutBCs, model, config) = begin
+#     BCs = nutBCs.parameters
+#     func_calls = Expr[]
+#     for i ∈ eachindex(BCs)
+#         BC = BCs[i]
+#         if BC <: NutWallFunction
+#             call = quote
+#                 correct_nut_wall!(BC, νtf, nutBCs[$i], model, config)
+#             end
+#             push!(func_calls, call)
+#         end
+#     end
+#     quote
+#     $(func_calls...)
+#     nothing
+#     end 
+# end
+
+@generated function correct_eddy_viscosity!(νtf, nutBCs, model, config)
+    unpacked_BCs = []
+    for i ∈ 1:length(nutBCs.parameters)
+        unpack = quote
+            correct_nut_wall!(BC, νtf, nutBCs[$i], model, config)
         end
+        push!(unpacked_BCs, unpack)
     end
     quote
-    $(func_calls...)
-    nothing
-    end 
+    # (; mesh) = phif
+    # (; boundary_cellsID, boundaries) = mesh 
+    # (; hardware) = config
+    # (; backend, workgroup) = hardware
+    # # b_cpu = Array{eltype(boundaries)}(undef, length(boundaries))
+    # # copyto!(b_cpu, boundaries)
+    # b_cpu = to_cpu(boundaries)
+
+    # backend = _get_backend(mesh)
+    $(unpacked_BCs...) 
+    end
 end
 
-function correct_nut_wall!(νtf, BC, model, config)
+correct_nut_wall!(BC, νtf, BC, model, config) = nothing
+
+function correct_nut_wall!(BC::NutWallFunction, νtf, BC, model, config)
     # backend = _get_backend(mesh)
     (; hardware) = config
     (; backend, workgroup) = hardware

--- a/src/ModelPhysics/Turbulence/RANS_functions.jl
+++ b/src/ModelPhysics/Turbulence/RANS_functions.jl
@@ -284,8 +284,8 @@ end
     (; U) = momentum
     (; k, nut) = turbulence
 
-    # Uw = SVector{3}(0.0,0.0,0.0)
-    Uw = U.BCs[BC.ID].value
+    Uw = SVector{3}(0.0,0.0,0.0)
+    # Uw = U.BCs[BC.ID].value
     cID = boundary_cellsID[fID]
     face = faces[fID]
     nuc = nu[cID]


### PR DESCRIPTION
Changes made to facilitate the implementation of user-defined boundary conditions functions. Specific changes include:

- Modified `correct_eddy_viscosity` function to use multiple dispatch to allow ease of implementation of new methods by users and clean implementation
-  `update_user_boundary` function arguments altered to expose the ModelEquation, allowing access to fluxes, fields and sources defined in a given model (as well as the underlying matrix and vector for the linear system Ax= b)
- Hard code wall velocity in set_production! function to avoid CUDA error (temporary solution).