### PR TITLE
High Fidelity Fluid Property Models for H2 and N2

### DIFF
--- a/src/ModelPhysics/Energy/PropertyModels/ThermalConductivity/thermal_conductivity_H2.jl
+++ b/src/ModelPhysics/Energy/PropertyModels/ThermalConductivity/thermal_conductivity_H2.jl
@@ -1,0 +1,167 @@
+export thermal_conductivity_H2
+
+###Refer to "Correlation of the Thermal Conductivity of Normal and Parahydrogen
+###                              from the Triple Point to 1000 K and up to 100MPa", 2011
+
+using Printf
+using XCALibre
+
+struct constants_k_H2
+    T_c::Float64
+    rho_c::Float64
+    P_CRIT::Float64
+    A1::Vector{Float64}
+    A2::Vector{Float64}
+    B1::Vector{Float64}
+    B2::Vector{Float64}
+    C1::Float64
+    C2::Float64
+    C3::Float64
+    R_D::Float64
+    ν::Float64
+    γ_crit::Float64
+    xi_0::Float64
+    GAMMA_0::Float64
+    qD::Float64
+    T_ref::Float64
+    k_B::Float64
+end
+
+function lambda0(T::Float64, constants::constants_k_H2)
+    (; T_c, A1, A2) = constants
+
+    T_r = T / T_c
+    numerator = sum(A1[i+1] * (T_r)^i for i in 0:7)
+    denominator = sum(A2[i+1] *(T_r)^i for i in 0:6)
+    return numerator / denominator
+end
+
+
+function delta_lambda(rho::Float64, T::Float64, constants::constants_k_H2)
+    (; T_c, rho_c, B1, B2) = constants
+
+    T_r = T / T_c
+    rho_r = rho / rho_c
+
+    term_sum = 0.0
+    for i in 1:5
+        term_sum += (B1[i] + (B2[i] * T_r) ) * (rho_r)^i
+    end
+    return term_sum
+end
+
+
+function delta_lambda_c_empirical(rho::Float64, T::Float64, constants::constants_k_H2) #The easy version
+    (; T_c, rho_c, C1, C2, C3) = constants
+
+    delta_T_c   = (T / T_c) - 1
+    delta_rho_c   = (rho / rho_c) - 1
+    denominator  = C2 + abs(delta_T_c)
+
+    if denominator <= 0.0
+        return 0.0
+    else
+        return (C1 / denominator) * exp(-(C3 * delta_rho_c)^2)
+    end
+end
+
+function xi(rho::Float64, T::Float64, kT::Float64, kT_ref::Float64, constants::constants_k_H2)
+    (; T_c, rho_c, P_CRIT, A1, A2, B1, B2, C1, C2, C3, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+    # kT = (1/rho) * (d rho / d p) at constant T
+    # kT is evaluated at T passed into delta_lambda_c, while kT_ref evaluated at T_ref
+    
+    nu_div_gamma = ν/γ_crit
+
+    term1 = xi_0 * ((P_CRIT*rho)/(GAMMA_0*(rho_c^2)))^nu_div_gamma
+
+    bracket_term = rho*kT - (T_ref/T)*(rho*kT_ref)
+
+    clamping = max(0.0, bracket_term)
+
+    term2 = clamping^nu_div_gamma
+
+    return term1 * term2
+end
+
+function omega_0(rho::Float64, T::Float64, xi::Float64, constants::constants_k_H2)
+    (; T_c, rho_c, P_CRIT, A1, A2, B1, B2, C1, C2, C3, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+
+    rhoc_div_rho = rho_c / rho
+    denom = ( (qD*xi)^(-1.0) ) + ( ( ( qD*xi*rhoc_div_rho )^2.0 )/3.0 )
+    exponent_term = -(1.0/denom)
+    
+    return (2.0/pi) * (1.0 - exp(exponent_term))
+end
+
+function omega(rho::Float64, T::Float64, xi::Float64, cp::Float64, cv::Float64, constants::constants_k_H2)
+    (; T_c, rho_c, P_CRIT, A1, A2, B1, B2, C1, C2, C3, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+
+    term1 = ( (cp-cv)/cp ) * atan(qD*xi)
+
+    term2 = (cv/cp) * qD * xi
+
+    exponent_term = term1 + term2
+
+    return (2.0/pi) * (exponent_term)
+end
+
+#The tricky one!
+function delta_lambda_c(rho::Float64, T::Float64, cp::Float64, cv::Float64, kT::Float64, 
+    kT_ref::Float64, nu_bar::Float64, constants::constants_k_H2)
+
+    (; T_c, rho_c, P_CRIT, A1, A2, B1, B2, C1, C2, C3, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+
+    tol=1.0e-12
+    xi_val = xi(rho, T, kT, kT_ref, constants)
+
+    if (xi_val < tol)
+        return 0.0
+    end
+
+    omega_0_val = omega_0(rho, T, xi_val, constants)
+    omega_val = omega(rho, T, xi_val, cp, cv, constants)
+
+    numerator = rho*cp*R_D*k_B*T
+    denominator = 6.0*pi*nu_bar*xi_val
+
+    return (numerator/denominator)*(omega_val-omega_0_val)
+end
+
+
+function thermal_conductivity_H2(rho::Float64, T::Float64, cp::Float64, cv::Float64, kT::Float64, 
+    kT_ref::Float64, nu_bar::Float64)
+
+    constants = constants_k_H2(
+        32.938, #T_c
+        31.323, #rho_c
+        1.2858e6, #P_CRIT
+        [-1.245, 310.212, -331.004, 246.016, -65.781, 10.826, -0.519659, 0.0143979], #A1
+        [1.42304e4, -1.93922e4,  1.58379e4, -4.81812e3, 7.28639e2, -3.57365e1,  1.00000e0], #A2
+        [2.65975e-2, -1.33826e-3,  1.30219e-2, -5.67678e-3, -9.23380e-5], #B1
+        [-1.21727e-3,  3.66663e-3,  3.88715e-3, -9.21055e-3,  4.00723e-3], #B2
+        3.57e-4, -2.46e-2, 0.2, #C1, C2, C3
+        1.01, #R_D
+        0.63, #ν
+        1.2415, #γ_crit
+        1.5e-10, #xi_0
+        0.052, #GAMMA_0
+        1.0 / 5.0e-10, #qD
+        49.7175, #T_ref
+        1.380649e-23 #k_B
+    )
+
+    (; T_c, rho_c, P_CRIT, A1, A2, B1, B2, C1, C2, C3, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+
+    lambda_0_val = lambda0(T, constants)
+    delta_lambda_val = delta_lambda(rho, T, constants)
+
+    lambda_crit_val = 0.0
+
+    if abs(T_c - T) < 7.0 # If it is close to critical point (within 7 K) - use complex function
+        lambda_crit_val = delta_lambda_c(rho, T, cp, cv, kT, kT_ref, nu_bar, constants)
+    else # Otherwise simpler function is good enough
+        lambda_crit_val = delta_lambda_c_empirical(rho, T, constants)
+    end
+
+    return lambda_0_val + delta_lambda_val + lambda_crit_val
+end

--- a/src/ModelPhysics/Energy/PropertyModels/ThermalConductivity/thermal_conductivity_N2.jl
+++ b/src/ModelPhysics/Energy/PropertyModels/ThermalConductivity/thermal_conductivity_N2.jl
@@ -1,0 +1,210 @@
+export thermal_conductivity_N2
+
+###Refer to "Viscosity and Thermal Conductivity Equations for Nitrogen, Oxygen, Argon, and Air", 2004
+
+using XCALibre
+using Printf
+
+struct constants_k_N2
+    T_c::Float64
+    rho_c::Float64
+    P_CRIT::Float64
+    M::Float64
+
+    epsilon_k::Float64 # epsilon/k
+    sigma::Float64
+
+    b::Vector{Float64}
+
+    N_L0::Vector{Float64}
+    t_L0::Vector{Float64}
+
+    N_LR::Vector{Float64}
+    t_LR::Vector{Float64}
+    d_LR::Vector{Float64}
+    l_LR::Vector{Float64}
+
+    R_D::Float64
+    ν::Float64
+    γ_crit::Float64
+    xi_0::Float64
+    GAMMA_0::Float64
+    qD::Float64
+    T_ref::Float64
+    k_B::Float64
+end
+
+
+
+function mu_0_N2_supplementary(T::Float64, constants::constants_k_N2)
+    (; M, sigma, epsilon_k, b) = constants
+    
+    Tstar = T / epsilon_k
+    ln_Tstar = log(Tstar)
+    
+    ln_sum = b[1] + b[2]*ln_Tstar + b[3]*ln_Tstar^2 + b[4]*ln_Tstar^3 + b[5]*ln_Tstar^4
+    omega  = exp(ln_sum)
+    
+    return ( 0.0266958 * sqrt(M * T) ) / ( (sigma)^2 * omega )
+end
+
+
+function lambda0_N2(T::Float64, constants::constants_k_N2)
+    (; T_c, N_L0, t_L0) = constants
+    
+    tau = T_c / T
+    
+    mu_0_val = mu_0_N2_supplementary(T, constants)
+
+    term1 = N_L0[1] * (mu_0_val)
+    term2 = N_L0[2] * (tau^t_L0[2])
+    term3 = N_L0[3] * (tau^t_L0[3])
+    
+    return term1 + term2 + term3
+end
+
+function lambda_r_N2(rho::Float64, T::Float64, constants::constants_k_N2)
+    (; T_c, rho_c, N_LR, t_LR, d_LR, l_LR) = constants
+
+    tau = T_c / T
+    delta = rho / rho_c
+
+    term_sum = 0.0
+    for i in eachindex(N_LR)
+        term = N_LR[i] * (tau^t_LR[i]) * (delta^d_LR[i])
+
+        # The paper states that an exponential term is included only when its exponent l_i is not zero..
+        if l_LR[i] != 0.0
+            term *= exp(-(delta^l_LR[i]))
+        end
+
+        term_sum += term
+    end
+    return term_sum
+end
+
+
+
+
+
+
+
+function xi(rho::Float64, T::Float64, kT::Float64, kT_ref::Float64, constants::constants_k_N2)
+    (; T_c, rho_c, P_CRIT, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B, M) = constants
+    # This piece of code is copied from Hydrogen file, it is just rearranged differently in the paper
+
+    # kT = (1/rho) * (d rho / d p) at constant T
+    # kT is evaluated at T passed into delta_lambda_c, while kT_ref evaluated at T_ref
+    
+    rho_c = rho_c * M
+
+    nu_div_gamma = ν/γ_crit
+
+    term1 = xi_0 * ((P_CRIT*rho)/(GAMMA_0*(rho_c^2)))^nu_div_gamma
+
+    bracket_term = rho*kT - (T_ref/T)*(rho*kT_ref)
+
+    clamping = max(0.0, bracket_term)
+
+    term2 = clamping^nu_div_gamma
+
+    return term1 * term2
+end
+
+function omega_0(rho::Float64, T::Float64, xi::Float64, constants::constants_k_N2)
+    (; T_c, rho_c, P_CRIT, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B, M) = constants
+
+    rho_c = rho_c * M
+
+
+    rhoc_div_rho = rho_c / rho
+    xi_div_qD = xi / qD
+
+    denom = ( (xi_div_qD)^(-1.0) ) + ( ( ( xi_div_qD*rhoc_div_rho )^2.0 )/3.0 )
+
+    exponent_term = (-1.0/denom)
+
+    return (2.0/pi) * (1.0 - exp(exponent_term))
+end
+
+function omega(rho::Float64, T::Float64, xi::Float64, cp::Float64, cv::Float64, constants::constants_k_N2)
+    (; T_c, rho_c, P_CRIT, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+
+    xi_div_qD = xi / qD
+
+    term1 = ( (cp-cv)/cp ) * atan(xi_div_qD)
+
+    term2 = (cv/cp) * xi_div_qD
+
+    exponent_term = term1 + term2
+
+    return (2.0/pi) * (exponent_term)
+end
+
+function lambda_c_N2(rho::Float64, T::Float64, cp::Float64, cv::Float64, kT::Float64, 
+    kT_ref::Float64, nu_bar::Float64, constants::constants_k_N2)
+
+    cp = cp * 1.0e3
+    cv = cv * 1.0e3
+    nu_bar = nu_bar * 1.0e-6
+
+    (; T_c, rho_c, P_CRIT, R_D, ν, γ_crit, xi_0, GAMMA_0, qD, T_ref, k_B) = constants
+
+    tol=1.0e-12
+    xi_val = xi(rho, T, kT, kT_ref, constants)
+
+    if (xi_val < tol)
+        return 0.0
+    end
+
+    omega_0_val = omega_0(rho, T, xi_val, constants)
+    omega_val = omega(rho, T, xi_val, cp, cv, constants)
+
+    numerator = rho*cp*R_D*k_B*T
+    denominator = 6.0*pi*nu_bar*xi_val
+
+    return (numerator/denominator)*(omega_val-omega_0_val)
+end
+
+
+
+
+function thermal_conductivity_N2(rho::Float64, T::Float64, cp::Float64, cv::Float64, kT::Float64, 
+    kT_ref::Float64, nu_bar::Float64)
+
+    constants = constants_k_N2(
+        126.192,     # T_c (K)
+        11.1839,     # rho_c (mol/dm^3)
+        3.3958e6,    # P_CRIT (Pa)
+        28.01348,    # M (g/mol)
+        98.94,       # epsilon_k (K)
+        0.3656,   # sigma (nm)
+        [0.431, -0.4623, 0.08406, 0.005341, -0.00331], # b_i coefficients
+        [1.511, 2.117, -3.332], # N_L0 (i=1 to 3)
+        [0.0, -1.0, -0.7],     # t_L0 (i=1 to 3, t1 is not used)
+        [8.862, 31.11, -73.13, 20.03, -0.7096, 0.2672], # N_LR (i=4 to 9)
+        [0.0, 0.03, 0.2, 0.8, 0.6, 1.9],               # t_LR (i=4 to 9)
+        [1.0, 2.0, 3.0, 4.0, 8.0, 10.0],                # d_LR (i=4 to 9)
+        [0.0, 0.0, 1.0, 2.0, 2.0, 2.0],                 # l_LR (i=4 to 9)
+        1.01,        # R_D (R_0 in paper)
+        0.63,        # nu
+        1.2415,      # gamma_crit
+        0.17e-9,     # xi_0
+        0.055,       # GAMMA_0
+        0.40e-9,     # qD
+        252.384,     # T_ref (K)
+        1.380658e-23 # k_B
+    )
+
+    rho_molar = rho / constants.M
+
+    lambda_0_val = lambda0_N2(T, constants)
+    lambda_r_val = lambda_r_N2(rho_molar, T, constants)
+    
+    lambda_crit_val = lambda_c_N2(rho, T, cp, cv, kT, kT_ref, nu_bar, constants)
+
+
+    thermal_conductivity = lambda_0_val + lambda_r_val + lambda_crit_val
+
+    return thermal_conductivity / 1000.0 # Convert mW into W
+end

--- a/src/ModelPhysics/Energy/PropertyModels/Viscosity/high_fidelity_mu_H2.jl
+++ b/src/ModelPhysics/Energy/PropertyModels/Viscosity/high_fidelity_mu_H2.jl
@@ -1,0 +1,75 @@
+export mu_high_fidelity_H2
+
+###Refer to "Correlation for the Viscosity of Normal Hydrogen Obtained from Symbolic Regression", 2013
+
+struct constants_mu_H2
+    M::Float64
+    sigma::Float64
+    epsilon_div_kb::Float64
+    T_c::Float64
+    rho_sc::Float64
+    a::Vector{Float64}
+    b::Vector{Float64}
+    c::Vector{Float64}
+end
+
+
+function mu_0(T::Float64, constants::constants_mu_H2) # so-called 'Zero-density Viscosity'
+    (; T_c, M, sigma, epsilon_div_kb, rho_sc, a, b) = constants
+    
+    Tstar = T / epsilon_div_kb
+    ln_Tstar = log(Tstar)
+    
+    ln_sum = a[1] + a[2]*ln_Tstar + a[3]*ln_Tstar^2 + a[4]*ln_Tstar^3 + a[5]*ln_Tstar^4
+    S_starT_star = exp(ln_sum)
+    
+    return ( 0.021357 * sqrt(M * T) ) / ( (sigma)^2 * S_starT_star )
+end
+
+
+function beta_mu(T::Float64, constants::constants_mu_H2) # 'Second viscosity viral coefficient'
+    (; T_c, M, sigma, epsilon_div_kb, rho_sc, a, b) = constants
+
+    Tstar = T / epsilon_div_kb
+    
+    Bstar = 0.0
+    for i in eachindex(b)
+        Bstar += b[i] * (Tstar^( -(i-1) )) #typo in article, fixed here
+    end
+    
+    return ((sigma^3)/3) * Bstar #typo in article, fixed here
+end
+
+
+function mu_1(T::Float64, constants::constants_mu_H2) # 'The initial-density coefficient of viscosity'
+    return mu_0(T, constants) * beta_mu(T, constants)
+end
+
+
+
+
+function mu_high_fidelity_H2(T::Float64, rho::Float64) # End result
+        
+    constants = constants_mu_H2(
+        2.01588, # M
+        0.297, # sigma
+        30.41, # epsilon_div_kb
+        33.145, # T_c
+        90.5, # rho_sc
+        [0.209630, -0.455274, 0.143602, -0.0335325, 0.00276981], # a
+        
+        [-0.1870, 2.4871, 3.7151, -11.0972, 9.0965, -3.8292, 0.5166], # b
+
+        [6.43449673, 4.56334068e-2, 0.232797868, 0.958326120,
+        0.127941189, 0.363576595] # c
+    )
+
+    (; T_c, M, sigma, epsilon_div_kb, rho_sc, a, b, c) = constants
+
+    T_r  = T / T_c
+    rho_r  = rho / rho_sc
+
+    exp_term = exp( c[2]*T_r + (c[3]/(T_r)) + ((c[4]*rho_r^2)/(c[5]+T_r)) + c[6]*(rho_r^6))
+
+    return mu_0(T, constants) + ( mu_1(T, constants) * rho ) + ( c[1] * (rho_r^2) ) * exp_term
+end

--- a/src/ModelPhysics/Energy/PropertyModels/Viscosity/high_fidelity_mu_N2.jl
+++ b/src/ModelPhysics/Energy/PropertyModels/Viscosity/high_fidelity_mu_N2.jl
@@ -1,0 +1,80 @@
+export mu_high_fidelity_N2
+
+### NOTE: this function works also with Oxygen, Air, Argon; different coeffs are required though
+
+###Refer to "Viscosity and Thermal Conductivity Equations for Nitrogen, Oxygen, Argon, and Air", 2004
+
+# Constants for Nitrogen (N2)
+
+struct constants_mu_N2
+    M::Float64
+    sigma::Float64
+    epsilon_div_kb::Float64
+    T_c::Float64
+    rho_c::Float64
+    b::NTuple{5, Float64}
+    N_coeffs::NTuple{5, Float64}
+    t_coeffs::NTuple{5, Float64}
+    d_coeffs::NTuple{5, Float64}
+    l_coeffs::NTuple{5, Float64}
+end
+
+
+function mu_0_N2(T::Float64, constants::constants_mu_N2)
+    (; M, sigma, epsilon_div_kb, b) = constants
+    Tstar = T / epsilon_div_kb
+    ln_Tstar = log(Tstar)
+    
+    ln_sum = b[1] + b[2]*ln_Tstar + b[3]*ln_Tstar^2 + b[4]*ln_Tstar^3 + b[5]*ln_Tstar^4
+    omega  = exp(ln_sum)
+    
+    return ( 0.0266958 * sqrt(M * T) ) / ( (sigma)^2 * omega )
+end
+
+function mu_r(δ::Float64, τ::Float64, constants::constants_mu_N2)
+    (; N_coeffs, t_coeffs, d_coeffs, l_coeffs) = constants
+    residual_viscosity = 0.0
+
+    for i in eachindex(N_coeffs)
+        
+        gamma = 0.0
+        
+        if l_coeffs[i] == 0
+            # If the exponent l is zero, gamma is zero
+            gamma = 0.0
+        else
+            # If the exponent l is not zero, gamma is one
+            gamma = 1.0
+        end
+
+        term = N_coeffs[i] * (τ^t_coeffs[i]) * (δ^d_coeffs[i]) * exp(-gamma * (δ^l_coeffs[i]))
+        residual_viscosity += term
+    end
+
+    return residual_viscosity
+end
+
+function mu_high_fidelity_N2(T::Float64, rho::Float64)
+
+    constants = constants_mu_N2(
+        28.01348, # M
+        0.3656, # sigma
+        98.94, # epsilon_div_kb
+        126.192, # T_c
+        11.1839, # rho_c
+        ( 0.431, -0.4623, 0.08406, 0.005341, -0.00331 ), # b
+        (10.72, 0.03989, 0.001208, -7.402, 4.620), # N_coeffs
+        (0.1, 0.25, 3.2, 0.9, 0.3), # t_coeffs
+        (2, 10, 12, 2, 1), # d_coeffs
+        (0, 1, 1, 2, 3) # l_coeffs
+    )
+    
+    (; M, T_c, rho_c) = constants
+
+    rho = rho / M
+
+    τ = T_c / T
+    δ = rho / rho_c
+
+    return mu_0_N2(T, constants) + mu_r(δ, τ, constants)
+end

--- a/src/ModelPhysics/Energy/PropertyModels/surface_tension.jl
+++ b/src/ModelPhysics/Energy/PropertyModels/surface_tension.jl
@@ -1,0 +1,33 @@
+export calculate_surface_tension
+
+###Refer to "Recommended Correlations for the Surface Tension of Common Fluids", 2012
+
+struct SurfaceTensionProperties{T<:AbstractFloat}
+    T_c::T   # Critical temperature
+    σ_0::T
+    n_0::T 
+    T_min::T # Minimum valid temperature
+    T_max::T # Maximum valid temperature
+end
+
+function get_surface_tension_properties(::H2)
+    return SurfaceTensionProperties(32.938, 0.005314, 1.060, 13.80, 31.00)
+end
+
+function get_surface_tension_properties(::N2)
+    return SurfaceTensionProperties(126.192, 0.02898, 1.246, 64.80, 120.24)
+end
+
+function calculate_surface_tension(fluid::HelmholtzEnergyFluid, T::AbstractFloat)
+    properties = get_surface_tension_properties(fluid)
+
+    if !(properties.T_min <= T <= properties.T_max)
+        return 0.0
+    end
+    
+    reduced_temp_term = 1.0 - (T / properties.T_c)
+    
+    surface_tension = properties.σ_0 * (reduced_temp_term^properties.n_0)
+
+    return surface_tension
+end

--- a/src/prototype/setField_utility.jl
+++ b/src/prototype/setField_utility.jl
@@ -1,0 +1,71 @@
+export setField_Box!, setField_Sphere!
+
+using LinearAlgebra
+
+
+function setField_Box!(mesh, field, value::Float64, region::String)
+# example of region: region_to_initialize = "(0 0 -1) (0.05 0.1 1)"
+
+    coords = map(s -> parse(Float64, s), split(replace(region, r"[()]" => ""))) #split input region into array of coords
+    p1 = coords[1:3] #min corner of the box
+    p2 = coords[4:6] #max corner of the box
+    
+    min_corner = min.(p1, p2) #account for any order of input coords
+    max_corner = max.(p1, p2) #account for any order of input coords
+
+    cells_in_region = Int[]
+    
+    for (id, cell) in enumerate(mesh.cells) #check that X, Y, Z coords are within the box
+        center = cell.centre
+        if (min_corner[1] <= center[1] <= max_corner[1] &&
+            min_corner[2] <= center[2] <= max_corner[2] &&
+            min_corner[3] <= center[3] <= max_corner[3])
+            
+            push!(cells_in_region, id)
+            # Warning: if outer cell boundary is outside the box but its centre is within the box, this cell will count too
+        end
+    end
+
+    if !isempty(cells_in_region)
+        field.values[cells_in_region] .= value # Reassign values inside the field
+    end
+    
+    return length(cells_in_region)
+end
+
+
+
+function setField_Sphere!(mesh, field, value::Float64, region::String)
+    
+    # region = "(x y z) r" would imply sphere in 3D
+    # region = "(x y) r" would imply circle in 2D
+
+    # THUS we need to check if we have 3 or 4 elements in our region string
+
+
+    coords = parse.(Float64, split(replace(region, r"[()]" => "")))
+
+
+    centre, radius = if length(coords) == 4 # 3D sphere
+        (coords[1:3], coords[4])
+    elseif length(coords) == 3 # 2D circle
+        ([coords[1], coords[2], 0.0], coords[3]) # Introduce 0.0 for the third dimension
+    else
+        error("Invalid region format!!!")
+    end
+
+
+    cells_in_region = Int[]
+
+    for (id, cell) in enumerate(mesh.cells) # Loop over cells and select those that are inside desired radius
+        if norm(cell.centre .- centre) <= radius # Check if the cell centre is less than 1 radius away from centre coord
+            push!(cells_in_region, id)
+        end
+    end
+
+    if !isempty(cells_in_region)
+        field.values[cells_in_region] .= value # Reassign values inside the field
+    end
+
+    return length(cells_in_region)
+end


### PR DESCRIPTION
- Added `setFields` utility that is similar to OpenFOAM. Currently, it can set field values within regions defined by a `square`, a `box`, a `circle`, or a `sphere`.