### PR TITLE
Improved stability of solvers (incompressible)  and code clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The constructors for `ScalarField` and `FaceScalarField` now include a `store_mesh` keyword argument to request a reference of the mesh to be stored (default) or not (setting `store_mesh=false`). This can be used to not include references to the mesh for each field in `VectorFields` and `TensorFields`. This has improved compile times and decreased simulation times (particularly on the GPU - perhaps due to freeing registers used to carry unnecessary type information) [#69](@ref)
 * Internally, the calculation of interpolation weights and other geometric properties are calculated using the same function (defined in the `Mesh` module) [#69](@ref)
 * The default discretisation for laplacian terms uses the over-relaxed formulation by default. This will have no effect on orthogonal grids, but tends to be more robust in complex geometries at the expense of accuracy, which can be recovered by adding additional orthogonal correction loops (using the key word argument `ncorrectors` in the `run!` function) [#73](@ref)
+* Cleaned code for all solvers and improved stability of incompressible solver by removing the update of the mass flow based on the velocity field from the previous iteration. The mass flow is now corrected directly from the latest pressure solution [#76](@ref)
 
 ### Breaking
 * No breaking changes

--- a/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmegaLKE.jl
@@ -354,10 +354,12 @@ function turbulence!(
 
     #Update ω fluxes
     # double_inner_product!(Pk, S, gradU) # multiplied by 2 (def of Sij) (Pk = S² at this point)
-    interpolate!(kf, k, config)
-    correct_boundaries!(nutf, k, boundaries.k, time, config)
-    interpolate!(omegaf, omega, config)
-    correct_boundaries!(nutf, omega, boundaries.omega, time, config)
+    # interpolate!(kf, k, config)
+    # correct_boundaries!(nutf, k, boundaries.k, time, config)
+    # correct_boundaries!(kf, k, boundaries.k, time, config)
+    # interpolate!(omegaf, omega, config)
+    # correct_boundaries!(nutf, omega, boundaries.omega, time, config)
+    # correct_boundaries!(nutf, omega, boundaries.omega, time, config)
     grad!(∇ω, omegaf, omega, boundaries.omega, time, config)
     grad!(∇k, kf, k, boundaries.k, time, config)
     inner_product!(dkdomegadx, ∇k, ∇ω, config)

--- a/src/Solve/Solve_1_api.jl
+++ b/src/Solve/Solve_1_api.jl
@@ -202,7 +202,8 @@ function solve_equation!(
     resy = solve_system!(psiEqn, solversetup, psi.y, ydir, config)
     
     # Z velocity calculations (3D Mesh only)
-    resz = one(_get_float(mesh))
+    # resz = one(_get_float(mesh))
+    resz = zero(_get_float(mesh))
     if typeof(mesh) <: Mesh3
         update_equation!(psiEqn, config)
         apply_boundary_conditions!(psiEqn, psiBCs, zdir, time, config)

--- a/src/Solvers/Solvers_1_CSIMPLE.jl
+++ b/src/Solvers/Solvers_1_CSIMPLE.jl
@@ -294,11 +294,6 @@ function CSIMPLE(
             @. rhof.values = Psif.values * pf.values
         end
 
-        # Velocity and boundaries correction
-        # correct_face_interpolation!(pf, p, Uf) # not needed added upwind interpolation
-        # correct_boundaries!(pf, p, boundaries.p, time, config)
-        # pgrad = face_normal_gradient(p, pf)
-
         if typeof(model.fluid) <: Compressible
             # @. mdotf.values += (pconv.values*(pf.values) - pgrad.values*rhorDf.values)  
             correct_mass_flux(mdotf, p, rhorDf, config)
@@ -309,8 +304,6 @@ function CSIMPLE(
         end
 
         correct_velocity!(U, Hv, ∇p, rD, config)
-        # interpolate!(Uf, U, config)
-        # correct_boundaries!(Uf, U, boundaries.U, time, config)
         
         turbulence!(turbulenceModel, model, S, prev, time, config) 
         update_nueff!(nueff, nu, model.turbulence, config)

--- a/src/Solvers/Solvers_1_LAPLACE.jl
+++ b/src/Solvers/Solvers_1_LAPLACE.jl
@@ -3,7 +3,6 @@ export LAPLACE
 export setup_laplace_solver
 
 
-
 """
     laplace!(model_in, config; 
         output=VTK(), pref=nothing, ncorrectors=0, inner_loops=0)

--- a/src/Solvers/Solvers_1_SIMPLE.jl
+++ b/src/Solvers/Solvers_1_SIMPLE.jl
@@ -138,7 +138,6 @@ function SIMPLE(
 
     # Pre-allocate auxiliary variables
     TF = _get_float(mesh)
-    # prev = zeros(TF, n_cells)
     # prev = _convert_array!(prev, backend) 
     prev = KernelAbstractions.zeros(backend, TF, n_cells) 
 
@@ -173,7 +172,6 @@ function SIMPLE(
         # Pressure correction
         inverse_diagonal!(rD, U_eqn, config)
         interpolate!(rDf, rD, config)
-        # correct_boundaries!(rDf, rD, rD.BCs, time, config) # ADDED FOR PERIODIC BCS
         remove_pressure_source!(U_eqn, ∇p, config)
         H!(Hv, U, U_eqn, config)
         
@@ -221,11 +219,6 @@ function SIMPLE(
         # flux!(mdotf, Uf, config) 
 
         # new approach
-
-        # 1. using velocity from momentum equation
-        # interpolate!(Uf, U, config)
-        # correct_boundaries!(Uf, U, boundaries.U, time, config)
-        # flux!(mdotf, Uf, config)
         correct_mass_flux(mdotf, p, rDf, config)
         correct_velocity!(U, Hv, ∇p, rD, config)
 

--- a/src/Solvers/Solvers_1_SIMPLE.jl
+++ b/src/Solvers/Solvers_1_SIMPLE.jl
@@ -142,10 +142,15 @@ function SIMPLE(
     prev = KernelAbstractions.zeros(backend, TF, n_cells) 
 
     # Pre-allocate vectors to hold residuals 
-    R_ux = ones(TF, iterations)
-    R_uy = ones(TF, iterations)
-    R_uz = ones(TF, iterations)
-    R_p = ones(TF, iterations)
+    # R_ux = ones(TF, iterations)
+    # R_uy = ones(TF, iterations)
+    # R_uz = ones(TF, iterations)
+    # R_p = ones(TF, iterations)
+
+    R_ux = zeros(TF, iterations)
+    R_uy = zeros(TF, iterations)
+    R_uz = zeros(TF, iterations)
+    R_p = zeros(TF, iterations)
     
     # Initial calculations
     time = zero(TF) # assuming time=0

--- a/src/Solvers/Solvers_2_PISO.jl
+++ b/src/Solvers/Solvers_2_PISO.jl
@@ -82,7 +82,7 @@ function PISO(
     R_uy = ones(TF, iterations)
     R_uz = ones(TF, iterations)
     R_p = ones(TF, iterations)
-    cellsCourant =adapt(backend, zeros(TF, length(mesh.cells)))
+    cellsCourant = KernelAbstractions.zeros(backend, TF, n_cells)
     
     # Initial calculations
     time = zero(TF) # assuming time=0
@@ -161,9 +161,6 @@ function PISO(
             # flux!(mdotf, Uf, config) # old approach
 
             # new approach
-            interpolate!(Uf, U, config) # velocity from momentum equation
-            correct_boundaries!(Uf, U, boundaries.U, time, config)
-            flux!(mdotf, Uf, config)
             correct_mass_flux(mdotf, p, rDf, config)
             correct_velocity!(U, Hv, ∇p, rD, config)
 
@@ -174,9 +171,6 @@ function PISO(
     turbulence!(turbulenceModel, model, S, prev, time, config) 
     update_nueff!(nueff, nu, model.turbulence, config)
 
-    # if typeof(mesh) <: Mesh3
-    #     residual!(R_uz, U_eqn, U.z, iteration, zdir, config)
-    # end
     maxCourant = max_courant_number!(cellsCourant, model, config)
 
     R_ux[iteration] = rx


### PR DESCRIPTION
This PR removes the correction of the mass flow based on the velocity field form the previous iteration, instead it should be corrected directly from the latest pressure field. This improves stability of incompressible solvers.