### PR TITLE
Fix mixed precision mesh conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed calculation of the residuals to use the relative residual norm, norm(b - Ax)/norm(b), the numerator in this expression was calculated incorrectly previously, giving a 1/sqrt(n) relation (where n is the number of cells in the grid). whilst the operation of the solvers remains the same, user may find that convergence criteria may need to be increased (specially for larger grids)[#102](@ref)
 * UNV2: Fix calculation of cell volumes and centroid for boundary cells was incorrect and missing boundary face contributions (only for 2D UNV meshes)[#106](@ref)
 * Fixed implementation of k-omega LKE transition model and how wall distance field is calculated to ensure it is GPU compatible [#109](@ref)
+* Fixed mixed-precision mesh conversion to preserve user-selected integer and floating-point types [#125](@ref)
+* Fixed pressure boundary mass-flux correction [#125](@ref)
+* Fixed turbulent effective viscosity updates so turbulence models include eddy viscosity again, reverting a regression introduced in [#120](@ref) [#125](@ref)
   
 ### Changed
 * Improved stability of `Periodic` boundaries by making the implementation fully implicit [#96](@ref)
@@ -30,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New method to enforce matrix symmetry of scalar model equations when the only term is a laplacian [#100](@ref)
 * Change calculation of face interpolation weights to use face normal aligned weights, this is more physical than the current method using face-based distances (in preparation for formal support for non-orthogonality correction)[#101](@ref)
 * 20x improvement loading and processing 3D UNV mesh files [#106](@ref)
+* Updated discretisation, boundary condition, turbulence, solver, and preconditioner paths to avoid unintended `Float64` promotion on `Float32` meshes [#125](@ref)
 
 ### Breaking
 * No breaking changes

--- a/src/Calculate/Calculate_0_gradient.jl
+++ b/src/Calculate/Calculate_0_gradient.jl
@@ -147,7 +147,9 @@ end
         c2 = ownerCells[2]
 
         # Interpolate calculation
-        phif[i] = 0.5*(phi[c1] + phi[c2])
+        phi1 = phi[c1]
+        half = typeof(phi1)(0.5)
+        phif[i] = half*(phi1 + phi[c2])
     end
 end
 
@@ -174,7 +176,6 @@ end
     @uniform begin
         # Extract individual value vectors from vector field
         (; x, y, z) = psif
-        weight = 0.5
     end
 
     @inbounds begin
@@ -186,6 +187,7 @@ end
         # Set values to interpolate between
         psi1 = psi[c1]
         psi2 = psi[c2]
+        weight = typeof(psi1[1])(0.5)
         midpoint = weight*(psi1 + psi2)
 
         # Interpolate calculation
@@ -205,22 +207,19 @@ function correct_interpolation!(grad, phif, phi, config)
     (; hardware) = config
     (; backend, workgroup) = hardware
 
-    # Retrieve user-selected float type
-    F = _get_float(mesh)
-    
-    # Set initial weight
-    weight = 0.5
+    # Set initial weight using the field storage type.
+    weight = eltype(phif)(0.5)
 
     # Launch correct interpolation kernel
     ndrange = length(faces) - nbfaces
     kernel! = correct_interpolation_kernel!(_setup(backend, workgroup, ndrange)...)
-    kernel!(faces, cells, nbfaces, phi, F, weight, grad, phif)
+    kernel!(faces, cells, nbfaces, phi, weight, grad, phif)
     # # KernelAbstractions.synchronize(backend)
 end
 
 # Correct interpolation kernel definition
 
-@kernel inbounds=true function correct_interpolation_kernel!(faces, cells, nbfaces, phi, F, weight, grad, phif::Field) where {Field}
+@kernel inbounds=true function correct_interpolation_kernel!(faces, cells, nbfaces, phi, weight, grad, phif::Field) where {Field}
     i = @index(Global)
     i += nbfaces # Set i such that it does not index boundary faces
 

--- a/src/Calculate/Calculate_1_green_gauss.jl
+++ b/src/Calculate/Calculate_1_green_gauss.jl
@@ -35,7 +35,8 @@ end
     @inbounds begin
         (; volume, faces_range) = cells[i]
 
-        res = SVector{3}(0.0,0.0,0.0)
+        z = zero(volume)
+        res = SVector{3}(z,z,z)
 
         for fi ∈ faces_range
             fID = cell_faces[fi]

--- a/src/Calculate/Calculate_2_interpolation.jl
+++ b/src/Calculate/Calculate_2_interpolation.jl
@@ -189,7 +189,7 @@ function interpolate!(
         grad2 = grad(cID2)
         # get weight for current scheme
         w, df = weight(get_scheme(grad), cells, faces, fID)
-        one_minus_weight = 1.0 - w
+        one_minus_weight = one(w) - w
         # calculate interpolated value
         grad_ave = w*grad1 + one_minus_weight*grad2
         # correct interpolation
@@ -199,4 +199,3 @@ function interpolate!(
         z[fID] = grad_corr[3]
     end
 end
-

--- a/src/Discretise/Discretise_1_schemes.jl
+++ b/src/Discretise/Discretise_1_schemes.jl
@@ -13,11 +13,13 @@ cIndex - Index of the cell based on sparse matrix. Use to index "nzval_array"
     term::Operator{F,P,I,Time{SteadyState}}, 
     nzval_array, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime)  where {F,P,I}
     # nothing
-    0.0, 0.0 # add types if this approach works
+    z = zero(eltype(nzval_array))
+    z, z
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Time{SteadyState}}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
-    0.0, 0.0
+    z = zero(cell.volume)
+    z, z
 end
 
 ## Euler
@@ -25,7 +27,8 @@ end
     term::Operator{F,P,I,Time{Euler}},
     nzval_array, cell, face, cellN, ns, cIndex, nIndex, fID, prev, runtime) where {F,P,I}
 
-    0.0, 0.0 # add types if this approach works
+    z = zero(eltype(nzval_array))
+    z, z
 end
 
 @inline scheme_source!(
@@ -46,7 +49,8 @@ end
     term::Operator{F,P,I,Time{CrankNicolson}}, 
     nzval_array, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime)  where {F,P,I}
 
-    0.0, 0.0 # add types if this approach works
+    z = zero(eltype(nzval_array))
+    z, z
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Time{CrankNicolson}}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
@@ -100,7 +104,8 @@ end
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Laplacian{Linear}}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
-    0.0, 0.0
+    z = zero(cell.volume)
+    z, z
 end
 
 # DIVERGENCE
@@ -113,7 +118,8 @@ end
 
     w = face.weight
     # signbit(ns) ? w = one(w) - w : w
-    w = 0.5 + ns*(w - 0.5)
+    half = typeof(w)(0.5)
+    w = half + ns*(w - half)
     
     # Calculate link coefficients
     ap = term.sign*(term.flux[fID]*ns)
@@ -123,7 +129,8 @@ end
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Divergence{Linear}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
-    0.0, 0.0
+    z = zero(cell.volume)
+    z, z
 end
 
 # Upwind
@@ -133,13 +140,15 @@ end
     )  where {F,P,I}
     # Calculate link coefficients
     ap = term.sign*(term.flux[fID]*ns)
-    ac = max(ap, 0.0) 
-    an = -max(-ap, 0.0)
+    z = zero(ap)
+    ac = max(ap, z)
+    an = -max(-ap, z)
     return ac, an
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Divergence{Upwind}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
-    0.0, 0.0
+    z = zero(cell.volume)
+    z, z
 end
 
 # LUST
@@ -155,15 +164,19 @@ end
     ap = term.sign*(term.flux[fID]*ns)
     acLinear = ap*w 
     anLinear = ap*(one(w) - w)
-    acUpwind = max(ap, 0.0) 
-    anUpwind = -max(-ap, 0.0)
-    ac = 0.75*acLinear + 0.25*acUpwind
-    an = 0.75*anLinear + 0.25*anUpwind
+    z = zero(ap)
+    acUpwind = max(ap, z)
+    anUpwind = -max(-ap, z)
+    three_quarters = typeof(ap)(0.75)
+    quarter = typeof(ap)(0.25)
+    ac = three_quarters*acLinear + quarter*acUpwind
+    an = three_quarters*anLinear + quarter*anUpwind
     return ac, an
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Divergence{LUST}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
-    0.0, 0.0
+    z = zero(cell.volume)
+    z, z
 end
 
 # BoundedUpwind
@@ -175,13 +188,15 @@ end
     # phif =  max(phif, 0) - max(-phi_f, 0)$
     # phif psif =  max(phif, 0) psi_P - max(-phi_f, 0)$ psi_N
     ap = term.sign*(term.flux[fID]*ns)
-    ac = max(-ap, 0.0)
-    an = -max(-ap, 0.0)
+    z = zero(ap)
+    ac = max(-ap, z)
+    an = -max(-ap, z)
     return ac, an
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Divergence{BoundedUpwind}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
-    0.0, 0.0
+    z = zero(cell.volume)
+    z, z
 end
 
 
@@ -190,7 +205,8 @@ end
     term::Operator{F,P,I,Si}, 
     nzval_array, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime
     )  where {F,P,I}
-    0.0, 0.0
+    z = zero(eltype(nzval_array))
+    z, z
 end
 @inline scheme_source!(
     term::Operator{F,P,I,Si}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
@@ -198,5 +214,5 @@ end
     # Retrieve and calculate flux for cell 
     flux = term.sign*term.flux[cID]*cell.volume # indexed with cID
     ac = flux # indexed with cIndex
-    ac, 0.0
+    ac, zero(ac)
 end

--- a/src/Discretise/Discretise_2_generated_distretisation.jl
+++ b/src/Discretise/Discretise_2_generated_distretisation.jl
@@ -170,7 +170,10 @@ return_quote(x, t) = :(nothing)
 
 # Scheme generated function definition
 # @generated function _scheme!(model::Model{TN,SN,T,S}, terms, nzval, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime) where {TN,SN,T,S}
-@generated function _scheme!(model::Model{TN,SN,T,S}, terms::TERMS, nzval, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime) where {TN,SN,T,S,TERMS}
+@generated function _scheme!(
+    model::Model{TN,SN,T,S}, terms::TERMS, nzval::AbstractArray{F}, cell, face,
+    cellN, ns, cIndex, nIndex, fID, prev, runtime
+    ) where {TN,SN,T,S,TERMS,F}
     # Allocate expression array to store scheme function
     out = Expr(:block)
 
@@ -178,22 +181,25 @@ return_quote(x, t) = :(nothing)
     for t in 1:TN
         function_call_scheme = quote
             ac, an = scheme!(terms[$t], nzval, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime)
-            AC += ac
-            AN += an
+            AC += F(ac)
+            AN += F(an)
         end
         push!(out.args, function_call_scheme)
     end
     # out
     quote
-        AC = 0.0
-        AN = 0.0
+        z = zero(F)
+        AC = z
+        AN = z
         $(out.args...)
         return AC, AN
     end
 end
 
 # Scheme source generated function definition
-@generated function _scheme_source!(model::Model{TN,SN,T,S}, terms::TERMS, cell, cID, cIndex, prev, runtime) where {TN,SN,T,S,TERMS}
+@generated function _scheme_source!(
+    model::Model{TN,SN,T,S}, terms::TERMS, cell::Cell{F}, cID, cIndex, prev, runtime
+    ) where {TN,SN,T,S,TERMS,F}
     # Allocate expression array to store scheme_source function
     out = Expr(:block)
     
@@ -202,16 +208,17 @@ end
         for t in 1:TN
             function_call_scheme_source = quote
                 ac, b = scheme_source!(terms[$t], cell, cID, cIndex, prev, runtime)
-                AC += ac
-                B += b
+                AC += F(ac)
+                B += F(b)
             end
             push!(out.args, function_call_scheme_source)
         end
         return quote
-            ac = 0.0
-            b = 0.0
-            AC = 0.0
-            B = 0.0
+            z = zero(F)
+            ac = z
+            b = z
+            AC = z
+            B = z
             $(out.args...)
             return AC, B
         end
@@ -221,22 +228,23 @@ end
                 ac, bx = scheme_source!(terms[$t], cell, cID, cIndex, prev.x, runtime)
                 ac, by = scheme_source!(terms[$t], cell, cID, cIndex, prev.y, runtime)
                 ac, bz = scheme_source!(terms[$t], cell, cID, cIndex, prev.z, runtime)
-                AC += ac # assuming ac's for all directions are equal
-                BX += bx
-                BY += by
-                BZ += bz
+                AC += F(ac) # assuming ac's for all directions are equal
+                BX += F(bx)
+                BY += F(by)
+                BZ += F(bz)
             end
             push!(out.args, function_call_scheme_source)
         end
         return quote
-            ac = 0.0
-            bx = 0.0
-            by = 0.0
-            bz = 0.0
-            AC = 0.0
-            BX = 0.0
-            BY = 0.0
-            BZ = 0.0
+            z = zero(F)
+            ac = z
+            bx = z
+            by = z
+            bz = z
+            AC = z
+            BX = z
+            BY = z
+            BZ = z
             $(out.args...)
             return AC, BX, BY, BZ
         end
@@ -244,7 +252,9 @@ end
 end
 
 # Sources generated function definition
-@generated function _sources!(model::Model{TN,SN,T,S}, sources::SRC, volume, cID) where {TN,SN,T,S,SRC}
+@generated function _sources!(
+    model::Model{TN,SN,T,S}, sources::SRC, volume::F, cID
+    ) where {TN,SN,T,S,SRC,F}
     # Allocate expression array to store source function
     out = Expr(:block)
 
@@ -253,12 +263,12 @@ end
         for s in 1:SN
             expression_call_sources = quote
                 (; field, sign) = sources[$s]
-                B += sign*field[cID]*volume
+                B += F(sign*field[cID]*volume)
             end
             push!(out.args, expression_call_sources)
         end
         return quote
-            B = 0.0
+            B = zero(F)
             $(out.args...)
             return B
         end
@@ -266,16 +276,17 @@ end
         for s in 1:SN
             expression_call_sources = quote
                 (; field, sign) = sources[$s]
-                Bx += sign*field.x[cID]*volume
-                By += sign*field.y[cID]*volume
-                Bz += sign*field.z[cID]*volume
+                Bx += F(sign*field.x[cID]*volume)
+                By += F(sign*field.y[cID]*volume)
+                Bz += F(sign*field.z[cID]*volume)
             end
             push!(out.args, expression_call_sources)
         end
         return quote
-            Bx = 0.0
-            By = 0.0
-            Bz = 0.0
+            z = zero(F)
+            Bx = z
+            By = z
+            Bz = z
             $(out.args...)
             return Bx, By, Bz
         end

--- a/src/Discretise/Discretise_3_boundary_conditions.jl
+++ b/src/Discretise/Discretise_3_boundary_conditions.jl
@@ -1,15 +1,19 @@
 
 # TRANSIENT TERM 
 @inline (bc::AbstractBoundary)( # Used for all schemes (using "T")
-    term::Operator{F,P,I,Time{T}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time
-    ) where {F,P,I,T} = begin
+    term::Operator{F,P,I,Time{T}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,T,TF} = begin
     # nothing
-    0.0, 0.0 # need to add consistent return types
+    z = zero(TF)
+    z, z
 end
 
 # KWallFunction
 @inline (bc::KWallFunction)(
-    term::Operator{F,P,I,Laplacian{T}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I,T}  = begin
+    term::Operator{F,P,I,Laplacian{T}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,T,TF}  = begin
     phi = term.phi 
     values = get_values(phi, component)
     J = term.flux[fID]
@@ -17,94 +21,119 @@ end
     flux = -J*area/delta
     ap = term.sign*(flux)
     ap, ap*values[cellID] # original
-    0.0, 0.0
+    z = zero(TF)
+    z, z
 end
 
 # OmegaWallFunction
 @inline (bc::OmegaWallFunction)(
-    term::Operator{F,P,I,Laplacian{T}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I,T} = begin
+    term::Operator{F,P,I,Laplacian{T}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,T,TF} = begin
     phi = term.phi 
     values = get_values(phi, component)
     J = term.flux[fID]
     (; area, delta) = face 
     flux = -J*area/delta
     ap = term.sign*(flux)
-    ap, ap*values[cellID] # original
+    TF(ap), TF(ap*values[cellID]) # original
     # 0.0, 0.0
 end
 
 # KWallFunction 
 @inline (bc::KWallFunction)(
-    term::Operator{F,P,I,Divergence{Linear}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{Linear}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF} = begin
     flux = term.flux[fID]
     ap = term.sign*(flux) 
-    ap, 0.0 # original
+    TF(ap), zero(TF) # original
 end
 
 # OmegaWallFunction 
 @inline (bc::OmegaWallFunction)(
-    term::Operator{F,P,I,Divergence{Linear}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I}  = begin
+    term::Operator{F,P,I,Divergence{Linear}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF}  = begin
     flux = term.flux[fID]
     ap = term.sign*(flux) 
-    ap, 0.0 # original
+    TF(ap), zero(TF) # original
 end
 
 # KWallFunction
 @inline (bc::KWallFunction)(
-    term::Operator{F,P,I,Divergence{LUST}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{LUST}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF} = begin
     flux = term.flux[fID]
     ap = term.sign*(flux) 
-    ap, 0.0 # original
+    TF(ap), zero(TF) # original
 end
 
 @inline (bc::KWallFunction)(
-    term::Operator{F,P,I,Divergence{Upwind}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{Upwind}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF} = begin
     flux = term.flux[fID]
     ap = term.sign*(flux) 
-    ap, 0.0 # original
+    TF(ap), zero(TF) # original
 end
 
 @inline (bc::KWallFunction)(
-    term::Operator{F,P,I,Divergence{BoundedUpwind}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{BoundedUpwind}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF} = begin
     flux = term.flux[fID]
     ap = term.sign*(flux)
-    ap-flux, 0.0
+    TF(ap-flux), zero(TF)
 end
 
 # OmegaWallFunction
 @inline (bc::OmegaWallFunction)(
-    term::Operator{F,P,I,Divergence{LUST}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I}  = begin
+    term::Operator{F,P,I,Divergence{LUST}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF}  = begin
     flux = term.flux[fID]
     ap = term.sign*(flux) 
-    ap, 0.0 # original
+    TF(ap), zero(TF) # original
 end
 
 @inline (bc::OmegaWallFunction)(
-    term::Operator{F,P,I,Divergence{Upwind}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I}  = begin
+    term::Operator{F,P,I,Divergence{Upwind}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF}  = begin
     flux = term.flux[fID]
     ap = term.sign*(flux) 
-    ap, 0.0 # original
+    TF(ap), zero(TF) # original
 end
 
 @inline (bc::OmegaWallFunction)(
-    term::Operator{F,P,I,Divergence{BoundedUpwind}}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I}  = begin
+    term::Operator{F,P,I,Divergence{BoundedUpwind}}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF}  = begin
     flux = term.flux[fID]
     ap = term.sign*(flux)
-    ap-flux, 0.0
+    TF(ap-flux), zero(TF)
 end
 
 # KWallFunction 
 @inline (bc::KWallFunction)(
-    term::Operator{F,P,I,Si}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = begin
-    0.0, 0.0
+    term::Operator{F,P,I,Si}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF} = begin
+    z = zero(TF)
+    z, z
 end
 
 # OmegaWallFunction 
 @inline (bc::OmegaWallFunction)(
-    term::Operator{F,P,I,Si}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = begin
+    term::Operator{F,P,I,Si}, colval, rowptr, nzval, cellID, zcellID,
+    cell::Cell{TF}, face, fID, i, component, time
+    ) where {F,P,I,TF} = begin
 
     # phi = term.phi[cellID] 
     # flux = term.sign*term.flux[cellID]
 
-    0.0, 0.0
+    z = zero(TF)
+    z, z
 end

--- a/src/Discretise/Discretise_5_apply_bcs.jl
+++ b/src/Discretise/Discretise_5_apply_bcs.jl
@@ -170,8 +170,9 @@ end
 
 # Apply generated function definition
 @generated function apply!(
-    model::Model{TN,SN,T,S}, BC, terms, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time
-    ) where {TN,SN,T,S}
+    model::Model{TN,SN,T,S}, BC, terms, colval, rowptr, nzval::AbstractArray{F},
+    cellID, zcellID, cell, face, fID, i, component, time
+    ) where {TN,SN,T,S,F}
 
     # Definition of main assignment loop (one per patch)
     func_calls = Expr[]
@@ -181,14 +182,15 @@ end
                 terms[$t], 
                 colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time
                 )
-            AP += ap
-            BP += bp
+            AP += F(ap)
+            BP += F(bp)
         end
         push!(func_calls, call)
     end
     quote
-        AP = 0.0
-        BP = 0.0
+        z = zero(F)
+        AP = z
+        BP = z
         $(func_calls...)
         return AP, BP
     end
@@ -214,4 +216,3 @@ end
         return BC_indices
     end
 end
-

--- a/src/Discretise/boundary_conditions/0_definition_macro.jl
+++ b/src/Discretise/boundary_conditions/0_definition_macro.jl
@@ -45,18 +45,34 @@ When called, this functor will return two values `ap` and `an`, where `ap` is th
 """
 macro define_boundary(boundary, operator, definition)
     quote
-        @inline (bc::$boundary)(term::Operator{F,P,I,$operator}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P,I} = 
+        @inline function (bc::$boundary)(
+            term::Operator{F,P,I,$operator}, colval, rowptr, nzval,
+            cellID::TI, zcellID::TZI, cell::Cell{TF}, face, fID::TFI, i::TBI,
+            component, time
+            ) where {F,P,I,TF,TI,TZI,TFI,TBI}
         @inbounds begin
-            $definition
+            ap, bp = begin
+                $definition
+            end
+            return TF(ap), TF(bp)
+        end
         end
     end |> esc
 end
 
 macro define_boundary(boundary, operator, FieldType, definition)
     quote
-        @inline (bc::$boundary)(term::Operator{F,P,I,$operator}, colval, rowptr, nzval, cellID, zcellID, cell, face, fID, i, component, time) where {F,P<:$FieldType,I} = 
+        @inline function (bc::$boundary)(
+            term::Operator{F,P,I,$operator}, colval, rowptr, nzval,
+            cellID::TI, zcellID::TZI, cell::Cell{TF}, face, fID::TFI, i::TBI,
+            component, time
+            ) where {F,P<:$FieldType,I,TF,TI,TZI,TFI,TBI}
         @inbounds begin
-            $definition
+            ap, bp = begin
+                $definition
+            end
+            return TF(ap), TF(bp)
+        end
         end
     end |> esc
 end

--- a/src/Discretise/boundary_conditions/dirichlet.jl
+++ b/src/Discretise/boundary_conditions/dirichlet.jl
@@ -75,8 +75,9 @@ end
     # 0.0, -ap*bc.value[component.value]
 
     ap = term.sign*(term.flux[fID])
-    ac = max(-ap, 0.0)
-    an = -max(-ap, 0.0)
+    z = zero(ap)
+    ac = max(-ap, z)
+    an = -max(-ap, z)
     ac, -an*bc.value[component.value]
 end
 
@@ -87,8 +88,9 @@ end
     # 0.0, -ap*bc.value
 
     ap = term.sign*(term.flux[fID])
-    ac = max(-ap, 0.0)
-    an = -max(-ap, 0.0)
+    z = zero(ap)
+    ac = max(-ap, z)
+    an = -max(-ap, z)
     ac, -an*bc.value
 end
 

--- a/src/Discretise/boundary_conditions/fixedTemperature.jl
+++ b/src/Discretise/boundary_conditions/fixedTemperature.jl
@@ -119,8 +119,9 @@ end
     # 0.0, -ap*h
     
     ap = term.sign*(term.flux[fID])
-    ac = max(-ap, 0.0)
-    an = -max(-ap, 0.0)
+    z = zero(ap)
+    ac = max(-ap, z)
+    an = -max(-ap, z)
     h = energy_model(T)
     ac, -an*h
 end
@@ -134,4 +135,3 @@ end
     h = energy_model(T)
     ap, ap*h
 end
-

--- a/src/Discretise/boundary_conditions/periodic.jl
+++ b/src/Discretise/boundary_conditions/periodic.jl
@@ -254,7 +254,7 @@ function periodic_matrix_connectivity(BC::PeriodicParent, mesh)
 end
 
 @define_boundary Periodic Laplacian{Linear} begin
-    return 0.0, 0.0
+    zero(TF), zero(TF)
 end
 
 # @define_boundary Union{PeriodicParent,Periodic} Laplacian{Linear} begin
@@ -308,7 +308,7 @@ end
     PN = spindex(rowptr, colval, cellID, pcellID)
     Atomix.@atomic nzval[PN] += -gamma
 
-    return gamma, 0.0 # PP assigned first value returned
+    gamma, zero(gamma) # PP assigned first value returned
 end
 
 @define_boundary Periodic Divergence{Linear} begin
@@ -354,7 +354,7 @@ end
 
     # now handle master cell 
     Atomix.@atomic nzval[PN] += an
-    return ac, 0.0
+    ac, zero(ac)
 end
 
 @define_boundary Periodic Divergence{Upwind} begin
@@ -374,8 +374,9 @@ end
     pcellID = pface.ownerCells[1]
 
     mdot = term.sign*(term.flux[fID])
-    ap = max(mdot, 0.0) # flow leaves master
-    an = -max(-mdot, 0.0) # flow leaves shadow
+    z = zero(mdot)
+    ap = max(mdot, z) # flow leaves master
+    an = -max(-mdot, z) # flow leaves shadow
 
     NN = spindex(rowptr, colval, pcellID, pcellID)
     NP = spindex(rowptr, colval, pcellID, cellID)
@@ -387,7 +388,7 @@ end
 
     # now handle master cell 
     Atomix.@atomic nzval[PN] += an
-    return ap, 0.0
+    ap, zero(ap)
 end
 
 @define_boundary Periodic Divergence{LUST} begin
@@ -420,10 +421,13 @@ end
     mdot = term.sign*(term.flux[fID])
     acLinear = mdot*w 
     anLinear = mdot*wn
-    acUpwind = max(mdot, 0.0) 
-    anUpwind = -max(-mdot, 0.0)
-    ac = 0.75*acLinear + 0.25*acUpwind
-    an = 0.75*anLinear + 0.25*anUpwind
+    z = zero(mdot)
+    acUpwind = max(mdot, z)
+    anUpwind = -max(-mdot, z)
+    three_quarters = TF(0.75)
+    quarter = TF(0.25)
+    ac = three_quarters*acLinear + quarter*acUpwind
+    an = three_quarters*anLinear + quarter*anUpwind
 
     NN = spindex(rowptr, colval, pcellID, pcellID)
     NP = spindex(rowptr, colval, pcellID, cellID)
@@ -435,7 +439,7 @@ end
 
     # now handle master cell 
     Atomix.@atomic nzval[PN] += an
-    return ac, 0.0
+    ac, zero(ac)
 end
 
 @define_boundary Union{PeriodicParent,Periodic} Si begin

--- a/src/Discretise/boundary_conditions/slip.jl
+++ b/src/Discretise/boundary_conditions/slip.jl
@@ -49,22 +49,24 @@ end
     nc = normal[component.value]
     vc_c = vc[component.value]
     vp_c = vp[component.value]
+    z = zero(ap)
+    one_minus_nc2 = one(nc) - nc^2
     
     # 1. Flow leaving (ap > 0): Implicit tensorial split
     # Diagonal is scaled by (1 - n^2) to strictly strip the normal contribution.
-    ac = max(ap, 0.0) * (1.0 - nc^2)
+    ac = max(ap, z) * one_minus_nc2
     
     # The remainder of the slip vector (cross-components) goes to deferred correction
-    su_leaving = -max(ap, 0.0) * (vp_c - vc_c * (1.0 - nc^2))
+    su_leaving = -max(ap, z) * (vp_c - vc_c * one_minus_nc2)
     
     # 2. Flow entering (ap < 0): Explicit Upwind Boundary evaluation
-    su_entering = -min(ap, 0.0) * vp_c
+    su_entering = -min(ap, z) * vp_c
     
     # Total explicit source
     su = su_entering + su_leaving
     
     ac, su
-    0.0, -ap*get_values(term.phi, component)[cellID]
+    zero(ap), -ap*get_values(term.phi, component)[cellID]
 end
 
 # @define_boundary Slip Divergence{Upwind} ScalarField begin
@@ -80,8 +82,9 @@ end
 @define_boundary Slip Divergence{Upwind} ScalarField begin
     flux = term.flux[fID]
     ap = term.sign*(flux)
-    ac = max(ap, 0.0)
-    su = -min(ap, 0.0) * get_values(term.phi, component)[cellID]
+    z = zero(ap)
+    ac = max(ap, z)
+    su = -min(ap, z) * get_values(term.phi, component)[cellID]
     ac, su
 end
 
@@ -134,7 +137,7 @@ end
     # Bounded form: ϕ_b(v_{f,i} - v_{P,i}) = -ϕ_b·n_i²·v_{P,i} + cross terms
     # Only inflow contributes safely to diagonal
     
-    F_upwind = max(-ap, 0.0)           # |ϕ_b| on inflow, 0 on outflow
+    F_upwind = max(-ap, zero(ap))      # |ϕ_b| on inflow, 0 on outflow
     
     # Implicit: diagonal coefficient from same-component
     ac = F_upwind * nc^2
@@ -159,16 +162,18 @@ end
 @define_boundary Slip Divergence{Linear} ScalarField begin
     flux = term.flux[fID]
     ap = term.sign*(flux)
-    ac = max(ap, 0.0)
-    su = -min(ap, 0.0) * get_values(term.phi, component)[cellID]
+    z = zero(ap)
+    ac = max(ap, z)
+    su = -min(ap, z) * get_values(term.phi, component)[cellID]
     ac, su
 end
 
 @define_boundary Slip Divergence{LUST} ScalarField begin
     flux = term.flux[fID]
     ap = term.sign*(flux)
-    ac = max(ap, 0.0)
-    su = -min(ap, 0.0) * get_values(term.phi, component)[cellID]
+    z = zero(ap)
+    ac = max(ap, z)
+    su = -min(ap, z) * get_values(term.phi, component)[cellID]
     ac, su
 end
 
@@ -186,13 +191,15 @@ end
     nc = normal[component.value]
     vc_c = vc[component.value]
     vp_c = vp[component.value]
+    z = zero(ap)
+    one_minus_nc2 = one(nc) - nc^2
     
     # Outflow (ap > 0): implicit same-component, defer cross terms
-    ac = max(ap, 0.0) * (1.0 - nc^2)
-    su_leaving = -max(ap, 0.0) * (vp_c - vc_c * (1.0 - nc^2))
+    ac = max(ap, z) * one_minus_nc2
+    su_leaving = -max(ap, z) * (vp_c - vc_c * one_minus_nc2)
     
     # Inflow (ap < 0): defer everything to source
-    su_entering = -min(ap, 0.0) * vp_c
+    su_entering = -min(ap, z) * vp_c
     
     ac, su_entering + su_leaving
 end
@@ -210,10 +217,12 @@ end
     nc = normal[component.value]
     vc_c = vc[component.value]
     vp_c = vp[component.value]
+    z = zero(ap)
+    one_minus_nc2 = one(nc) - nc^2
     
-    ac = max(ap, 0.0) * (1.0 - nc^2)
-    su_leaving = -max(ap, 0.0) * (vp_c - vc_c * (1.0 - nc^2))
-    su_entering = -min(ap, 0.0) * vp_c
+    ac = max(ap, z) * one_minus_nc2
+    su_leaving = -max(ap, z) * (vp_c - vc_c * one_minus_nc2)
+    su_entering = -min(ap, z) * vp_c
     
     ac, su_entering + su_leaving
 end

--- a/src/Discretise/boundary_conditions/wall.jl
+++ b/src/Discretise/boundary_conditions/wall.jl
@@ -74,8 +74,9 @@ end
 
 @define_boundary Wall Divergence{BoundedUpwind} ScalarField begin
     ap = term.sign*(term.flux[fID])
-    ac = max(-ap, 0.0)
-    an = -max(-ap, 0.0)
+    z = zero(ap)
+    ac = max(-ap, z)
+    an = -max(-ap, z)
     ac, -an*bc.value
 end
 

--- a/src/FoamMesh/FoamMesh_4_geometry.jl
+++ b/src/FoamMesh/FoamMesh_4_geometry.jl
@@ -12,14 +12,14 @@ function calculate_cell_centres!(mesh)
     (; nodes, cells, cell_nodes) = mesh
     TF = eltype(nodes[1].coords)
     for (cID, cell) ∈ enumerate(cells)
-        sum = SVector{3}(zeros(TF, 3))
+        sum = SVector{3, TF}(0, 0, 0)
         nodesID_range = cell.nodes_range
         nodesID = @view cell_nodes[nodesID_range]
         for nID ∈ nodesID
             sum += nodes[nID].coords
         end
         centre = sum/length(nodesID)
-        @reset cell.centre = centre 
+        @reset cell.centre = centre
         cells[cID] = cell
     end
     return mesh
@@ -30,14 +30,14 @@ function calculate_face_centres!(mesh)
 
     TF = eltype(nodes[1].coords)
     for (fID, face) ∈ enumerate(faces)
-        sum = SVector{3}(zeros(TF, 3))
+        sum = SVector{3, TF}(0, 0, 0)
         nodesID_range = face.nodes_range
         nodesID = @view face_nodes[nodesID_range]
         for nID ∈ nodesID
             sum += nodes[nID].coords
         end
         centre = sum/length(nodesID)
-        @reset face.centre = centre 
+        @reset face.centre = centre
         faces[fID] = face
     end
     return mesh
@@ -49,7 +49,6 @@ function calculate_face_properties!(mesh)
     n_faces = length(mesh.faces)
 
     TF = _get_float(mesh)
-    TI = _get_int(mesh)
 
     # loop over boundary faces
     for fID ∈ 1:n_bfaces
@@ -60,20 +59,20 @@ function calculate_face_properties!(mesh)
         node2 = nodes[nIDs[2]]
 
         F1 = face.centre
-        C1 = cells[ownerCells[1]].centre 
+        C1 = cells[ownerCells[1]].centre
 
         fc_n1 = node1.coords - F1
         fc_n2 = node2.coords - F1
-        C1F1 = F1 - C1 # distance vector from face centre to cell1 
+        C1F1 = F1 - C1 # distance vector from face centre to cell1
 
         normal_vec = fc_n1 × fc_n2
         normal = normal_vec/norm(normal_vec)
         if C1F1 ⋅ normal < 0
-            normal *= -one(TI)
+            normal = -normal
         end
         @reset face.normal = normal
 
-        # calculate weight, delta and e 
+        # calculate weight, delta and e
         weight, delta, e = Mesh.weight_delta_e(C1F1, normal)
         @reset face.delta = delta
         @reset face.e = e
@@ -89,18 +88,18 @@ function calculate_face_properties!(mesh)
         (; ownerCells) = face
         node1 = nodes[nIDs[1]]
         node2 = nodes[nIDs[2]]
-    
-        F1 = face.centre
-        C1 = cells[ownerCells[1]].centre 
-        C2 = cells[ownerCells[2]].centre 
 
-        C1F1 = F1 - C1 # distance vector from face centre to cell1 
+        F1 = face.centre
+        C1 = cells[ownerCells[1]].centre
+        C2 = cells[ownerCells[2]].centre
+
+        C1F1 = F1 - C1 # distance vector from face centre to cell1
         C2F1 = F1 - C2 # distance vector from face centre to cell2
         C1C2 = C2 - C1 # distance vector from cell1 to cell2
 
         # area-weighted face normal
-        sumArea = 0.0
-        sumNormals = SVector{3}(0.0,0.0,0.0)
+        sumArea = zero(TF)
+        sumNormals = SVector{3, TF}(0, 0, 0)
         nodeIDs = [nIDs..., nIDs[1]]
         for nodei ∈ eachindex(face.nodes_range)
             node1 = nodes[nodeIDs[nodei]]
@@ -108,16 +107,16 @@ function calculate_face_properties!(mesh)
             edge = node2.coords - node1.coords
             areaSwepti = edge × (face.centre - node1.coords)
             normi = norm(areaSwepti)
-            areai = 0.5*normi
-            normali = areaSwepti/normi 
-            sumNormals += areai*normali 
+            areai = TF(0.5)*normi
+            normali = areaSwepti/normi
+            sumNormals += areai*normali
             sumArea += areai
         end
         normal = sumNormals/sumArea
 
         # check normal points out of cell and correct otherwise
         if C1C2 ⋅ normal < 0
-            normal *= -one(TI)
+            normal = -normal
         end
         @reset face.normal = normal
 
@@ -126,17 +125,16 @@ function calculate_face_properties!(mesh)
         @reset face.delta = delta
         @reset face.e = e
         @reset face.weight = weight
-        
+
         faces[fID] = face
     end
     return mesh
 end
 
 function calculate_face_areas!(mesh)
-    (; nodes, faces, face_nodes) = mesh 
+    (; nodes, faces, face_nodes) = mesh
 
     TF = _get_float(mesh)
-    TI = _get_int(mesh)
 
     for (fID, face) = enumerate(faces)
         nIDs = face_nodes[face.nodes_range]
@@ -151,10 +149,10 @@ function calculate_face_areas!(mesh)
 
             n1_n2 = n2 - n1
             n1_f = f - n1
-            ec = (n1 + n2)/TI(2) # edge centre
+            ec = (n1 + n2)/TF(2) # edge centre
             xf = ec - f
             normal_plane = n1_f × n1_n2
-            normal_vec = normal_plane × n1_n2 
+            normal_vec = normal_plane × n1_n2
             edgeNormal = normal_vec/norm(normal_vec)
             edgeArea = norm(n1_n2)
             sum += xf⋅edgeNormal*edgeArea
@@ -169,7 +167,6 @@ function calculate_cell_volumes!(mesh)
     (; faces, cells, cell_faces, cell_nsign, boundaries, boundary_cellsID) = mesh
 
     TF = _get_float(mesh)
-    TI = _get_int(mesh)
 
     oneThird = TF(1/3)
 
@@ -191,7 +188,7 @@ function calculate_cell_volumes!(mesh)
         cells[cID] = cell
     end
 
-    # add contribution from boundary faces 
+    # add contribution from boundary faces
     for boundary ∈ boundaries
         IDs_range = boundary.IDs_range
         cIDs = @view boundary_cellsID[IDs_range]

--- a/src/FoamMesh/FoamMesh_5_build.jl
+++ b/src/FoamMesh/FoamMesh_5_build.jl
@@ -24,6 +24,7 @@ function FOAM3D_mesh(mesh_file; scale=1, integer_type=Int64, float_type=Float64)
     connectivity = connect_mesh(foamdata, integer_type, float_type)
     mesh = generate_mesh(foamdata, connectivity, integer_type, float_type)
     mesh = compute_geometry!(mesh)
+    Mesh.validate_single_precision_mesh(mesh; source="FOAM3D_mesh")
 
     return mesh
     # return foamdata

--- a/src/Mesh/Mesh_1_functions.jl
+++ b/src/Mesh/Mesh_1_functions.jl
@@ -4,6 +4,7 @@ export bounding_box
 export boundary_info, boundary_map
 export total_boundary_faces, boundary_index
 export norm_static
+export validate_single_precision_mesh
 # export x, y, z # access cell centres
 # export xf, yf, zf # access face centres
 
@@ -132,6 +133,56 @@ function boundary_index(boundaries::Vector{Boundary{S, UR}}, name::S) where {S<:
             return index 
         end
     end
+end
+
+function validate_single_precision_mesh(mesh::AbstractMesh; source="mesh conversion")
+    _get_float(mesh) === Float32 || return mesh
+
+    bad_cells = _count_invalid_positive(c.volume for c in mesh.cells)
+    bad_areas = _count_invalid_positive(f.area for f in mesh.faces)
+    bad_deltas = _count_invalid_positive(f.delta for f in mesh.faces)
+    bad_weights = count(f -> !isfinite(f.weight), mesh.faces)
+
+    max_coord = 0.0
+    for node in mesh.nodes
+        for coord in node.coords
+            max_coord = max(max_coord, abs(Float64(coord)))
+        end
+    end
+
+    min_delta = Inf
+    for face in mesh.faces
+        delta = Float64(face.delta)
+        if isfinite(delta) && delta > 0
+            min_delta = min(min_delta, delta)
+        end
+    end
+
+    spacing = Float64(eps(Float32)) * max(max_coord, 1.0)
+    underresolved = min_delta <= 16 * spacing
+
+    if bad_cells == 0 && bad_areas == 0 && bad_deltas == 0 && bad_weights == 0 && !underresolved
+        return mesh
+    end
+
+    msg = """
+    Single-precision mesh validation failed during $source.
+
+    The converted Float32 mesh contains geometry that is not reliable enough for single-precision solving:
+    - invalid cell volumes: $bad_cells
+    - invalid face areas: $bad_areas
+    - invalid face deltas: $bad_deltas
+    - non-finite interpolation weights: $bad_weights
+    - minimum positive face delta: $min_delta
+    - estimated Float32 coordinate spacing: $spacing
+
+    Use `float_type=Float64` for this mesh, or provide a mesh whose smallest geometric length scales are well above Float32 coordinate spacing.
+    """
+    throw(ArgumentError(msg))
+end
+
+function _count_invalid_positive(values)
+    count(v -> !isfinite(v) || v <= zero(v), values)
 end
 
 # function x(mesh::Mesh2{I,F}) where {I,F}

--- a/src/ModelPhysics/2_fluid_models.jl
+++ b/src/ModelPhysics/2_fluid_models.jl
@@ -63,9 +63,10 @@ end
 (fluid::Fluid{Incompressible, ARG})(mesh) where ARG = begin
     coeffs = fluid.args
     (; rho, nu) = coeffs
-    nu = ConstantScalar(nu)
+    scalar = ScalarFloat(mesh)
+    nu = ConstantScalar(scalar(nu))
     nuf = nu
-    rho = ConstantScalar(rho)
+    rho = ConstantScalar(scalar(rho))
     rhof = rho
     Incompressible(nu, rho, nuf, rhof)
 end
@@ -101,9 +102,10 @@ end
 (fluid::Fluid{Incompressible_MRF, ARG})(mesh) where ARG = begin
     coeffs = fluid.args
     (; rho, nu, refFrames) = coeffs
-    nu = ConstantScalar(nu)
+    scalar = ScalarFloat(mesh)
+    nu = ConstantScalar(scalar(nu))
     nuf = nu
-    rho = ConstantScalar(rho)
+    rho = ConstantScalar(scalar(rho))
     rhof = rho
     Incompressible_MRF(nu, rho, nuf, rhof, refFrames)
 end

--- a/src/ModelPhysics/Turbulence/RANS_kOmega.jl
+++ b/src/ModelPhysics/Turbulence/RANS_kOmega.jl
@@ -53,7 +53,14 @@ end
     kf = FaceScalarField(mesh)
     omegaf = FaceScalarField(mesh)
     nutf = FaceScalarField(mesh)
-    coeffs = rans.args
+    scalar = ScalarFloat(mesh)
+    coeffs = (
+        β⁺=scalar(rans.args.β⁺),
+        α1=scalar(rans.args.α1),
+        β1=scalar(rans.args.β1),
+        σk=scalar(rans.args.σk),
+        σω=scalar(rans.args.σω),
+    )
     KOmega(k, omega, nut, kf, omegaf, nutf, coeffs)
 end
 

--- a/src/ModelPhysics/Turbulence/RANS_tensor_algebra.jl
+++ b/src/ModelPhysics/Turbulence/RANS_tensor_algebra.jl
@@ -71,9 +71,10 @@ function magnitude2!(
     (; hardware) = config
     (; backend, workgroup) = hardware
 
+    scale = eltype(magS)(scale_factor)
     ndrange = length(magS)
     kernel! = _magnitude2!(_setup(backend, workgroup, ndrange)...)
-    kernel!(magS, S, scale_factor)
+    kernel!(magS, S, scale)
     # KernelAbstractions.synchronize(backend)
 end
 
@@ -85,7 +86,7 @@ end
     @uniform values = magS.values
 
     @inbounds begin
-        sum = 0.0
+        sum = zero(eltype(values))
         Sjk = S[i]
         for j ∈ 1:3
             for k ∈ 1:3
@@ -113,8 +114,7 @@ end
                 res =   Si⋅Si
         #     end
         # end
-        # magS.values[i] = sum*scale_factor
-        magS.values[i] = res
+        magS.values[i] = res*scale_factor
     end
 end
 
@@ -122,8 +122,9 @@ function square!(psi2, psi, config; scale_factor=1.0)
     (; hardware) = config
     (; backend, workgroup) = hardware
 
+    scale = eltype(psi2)(scale_factor)
     kernel! = _square!(backend, workgroup)
-    kernel!(psi2, psi, scale_factor, ndrange = length(psi2))
+    kernel!(psi2, psi, scale, ndrange = length(psi2))
     nothing
 end
 

--- a/src/Solve/Preconditioners/preconditioners_0_types.jl
+++ b/src/Solve/Preconditioners/preconditioners_0_types.jl
@@ -47,7 +47,7 @@ Preconditioner{NormDiagonal}(A::AbstractSparseArray{F,I}) where {F,I} = begin
     backend = get_backend(A)
     m, n = size(A)
     m == n || throw("Matrix not square")
-    S = _convert_array!(zeros(m), backend)
+    S = _convert_array!(zeros(F, m), backend)
     P = opDiagonal(S)
     Preconditioner{NormDiagonal,typeof(A),typeof(P),typeof(S)}(A,P,S)
 end
@@ -56,7 +56,7 @@ Preconditioner{Jacobi}(A::AbstractSparseArray{F,I}) where {F,I} = begin
     backend = get_backend(A)
     m, n = size(A)
     m == n || throw("Matrix not square")
-    S = _convert_array!(zeros(m), backend)
+    S = _convert_array!(zeros(F, m), backend)
     P = opDiagonal(S)
     Preconditioner{Jacobi,typeof(A),typeof(P),typeof(S)}(A,P,S)
 end

--- a/src/Solve/Preconditioners/preconditioners_2_functions.jl
+++ b/src/Solve/Preconditioners/preconditioners_2_functions.jl
@@ -58,7 +58,7 @@ end
         idx_next = rowptr[i+1]
         column_vals = @view nzval[idx_start:(idx_next-1)] 
         norm = norm_static(column_vals)
-        storage[i] = 1/norm
+        storage[i] = one(norm)/norm
     # end
 end
 
@@ -88,7 +88,8 @@ end
 
     @inbounds begin
         idx_diagonal = spindex(rowptr, colval, i, i)
-        storage[i] = 1/abs(nzval[idx_diagonal])
+        diagonal = abs(nzval[idx_diagonal])
+        storage[i] = one(diagonal)/diagonal
     end
 end
 

--- a/src/Solve/Solve_1_api.jl
+++ b/src/Solve/Solve_1_api.jl
@@ -359,7 +359,7 @@ end
     @inbounds begin
         nIndex = spindex(rowptr, colval, i, i)
         nzval[nIndex] /= alpha
-        b[i] += (1.0 - alpha)*nzval[nIndex]*field[i]
+        b[i] += (one(alpha) - alpha)*nzval[nIndex]*field[i]
     end
 end
 

--- a/src/Solvers/Solvers_0_functions.jl
+++ b/src/Solvers/Solvers_0_functions.jl
@@ -8,14 +8,14 @@ function update_nueff!(nueff, nu, turb_model, config)
     (; backend, workgroup) = hardware
 
     ndrange = length(nueff)
-    #if typeof(turb_model) <: Laminar
-    kernel! = update_nueff_laminar!(_setup(backend, workgroup, ndrange)...)
-    kernel!(nu, nueff)
-    #else
-        #(; nutf) = turb_model
-        #kernel! = update_nueff_turbulent!(_setup(backend, workgroup, ndrange)...)
-        #kernel!(nu, nutf, nueff)
-    #end
+    if typeof(turb_model) <: Laminar
+        kernel! = update_nueff_laminar!(_setup(backend, workgroup, ndrange)...)
+        kernel!(nu, nueff)
+    else
+        (; nutf) = turb_model
+        kernel! = update_nueff_turbulent!(_setup(backend, workgroup, ndrange)...)
+        kernel!(nu, nutf, nueff)
+    end
 
 end
 

--- a/src/Solvers/Solvers_0_functions.jl
+++ b/src/Solvers/Solvers_0_functions.jl
@@ -241,7 +241,7 @@ end
         sumy -= D*Uy[i]
         sumz -= D*Uz[i]
 
-        rD = 1.0/D
+        rD = one(D)/D
         Hx[i] = (bx[i] - sumx)*rD
         Hy[i] = (by[i] - sumy)*rD
         Hz[i] = (bz[i] - sumz)*rD
@@ -270,7 +270,7 @@ end
     dt = runtime.dt[1]
     umag = norm(U[i])
     volume = cells[i].volume
-    dx = volume^0.333333
+    dx = volume^(one(volume)/typeof(volume)(3))
     cellsCourant[i] = umag * dt / dx
 end
 
@@ -280,7 +280,7 @@ end
     dt = runtime.dt[1]
     umag = norm(U[i])
     volume = cells[i].volume
-    dx = volume^0.5
+    dx = sqrt(volume)
     cellsCourant[i] = umag * dt / dx
 end
 
@@ -290,7 +290,7 @@ update_dt!(runtime::Runtime{<:Any,<:Any,<:Any,Nothing}, courant) = nothing
 function update_dt!(runtime::Runtime{<:Any,<:Any,<:Any,<:AdaptiveTimeStepping}, courant)
     (; maxCo, maxGrow, minShrink) = runtime.adaptive
 
-    courant_factor = maxCo / (courant + eps())
+    courant_factor = maxCo / (courant + eps(courant))
     new_dt_factor = clamp(courant_factor, minShrink, maxGrow)
     runtime.dt .= runtime.dt .* new_dt_factor
 end

--- a/src/Solvers/Solvers_1_SIMPLE.jl
+++ b/src/Solvers/Solvers_1_SIMPLE.jl
@@ -305,7 +305,7 @@ end
     (; values) = grad.field
     weight, df = correction_weight(cells, faces, fID)
     # weight = face.weight
-    gradi = weight*grad[cID1] + (1.0 - weight)*grad[cID2]
+    gradi = weight*grad[cID1] + (one(weight) - weight)*grad[cID2]
     gradf = gradi + ((values[cID2] - values[cID1])/delta - (gradi⋅e))*e
     # gradf = gradi
 

--- a/src/Solvers/Solvers_1_SIMPLE.jl
+++ b/src/Solvers/Solvers_1_SIMPLE.jl
@@ -207,7 +207,7 @@ function SIMPLE(
         end
 
         # correct mass flux and velocity
-        correct_mass_flux!(mdotf, p_eqn, config)
+        correct_mass_flux!(mdotf, p_eqn, config; time=time)
         correct_velocity!(U, Hv, ∇p, rD, config)
 
         turbulence!(turbulenceModel, model, S, prev, time, config) 
@@ -337,7 +337,7 @@ end
 
 ### TEMP LOCATION FOR PROTOTYPING
 
-function correct_mass_flux!(mdotf, p_eqn, config)
+function correct_mass_flux!(mdotf, p_eqn, config; time=nothing)
     # sngrad = FaceScalarField(mesh)
     (; faces, cells, boundary_cellsID) = mdotf.mesh
     (; hardware) = config
@@ -358,12 +358,14 @@ function correct_mass_flux!(mdotf, p_eqn, config)
     kernel!(mdotf, p, nzval, colval, rowptr, faces, cells, n_bfaces)
     KernelAbstractions.synchronize(backend)
 
-    BCs = config.boundaries[1] # assume periodics always defined by user (extract first)
+    BCs = config.boundaries.p
     for BC ∈ BCs
         correct_mass_periodic(
             BC, mdotf, p, nzval, colval, rowptr, cells, faces, backend, workgroup)
         KernelAbstractions.synchronize(backend)
     end
+
+    correct_boundary_mass_flux!(mdotf, p_eqn, BCs, time, config)
 end
 
 @kernel function _correct_mass_flux!(
@@ -465,4 +467,91 @@ end
     phifi =  w*phi1 + one_w*phi2
     phif[fID] = phifi
     phif[pfID] = phifi
+end
+
+### Correct mass flux at pressure boundaries
+
+function correct_boundary_mass_flux!(mdotf, p_eqn, BCs, time, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+
+    pterm = p_eqn.model.terms[1]
+    p = pterm.phi
+    pflux = pterm.flux
+    psign = pterm.sign
+
+    (; faces, boundary_cellsID) = mdotf.mesh
+    ndrange = length(boundary_cellsID)
+    kernel! = _correct_boundary_mass_flux!(_setup(backend, workgroup, ndrange)...)
+    kernel!(BCs, mdotf, p, pflux, psign, faces, boundary_cellsID, time)
+    KernelAbstractions.synchronize(backend)
+end
+
+@kernel function _correct_boundary_mass_flux!(
+    BCs, mdotf, p, pflux, psign, faces, boundary_cellsID, time)
+    fID = @index(Global)
+
+    @inbounds begin
+        correct_boundary_mass_flux_dispatch!(
+            BCs, mdotf, p, pflux, psign, faces, boundary_cellsID, time, fID)
+    end
+end
+
+@generated function correct_boundary_mass_flux_dispatch!(
+    BCs, mdotf, p, pflux, psign, faces, boundary_cellsID, time, fID)
+
+    calls = Expr(:block)
+    for bci ∈ 1:length(BCs.parameters)
+        push!(calls.args, quote
+            BC = BCs[$bci]
+            (; start, stop) = BC.IDs_range
+            if start <= fID <= stop
+                i = fID - start + 1
+                correct_boundary_mass_flux_bc!(
+                    BC, mdotf, p, pflux, psign, faces, boundary_cellsID, time, i, fID)
+                return nothing
+            end
+        end)
+    end
+
+    return calls
+end
+
+@inline correct_boundary_mass_flux_bc!(
+    BC, mdotf, p, pflux, psign, faces, boundary_cellsID, time, i, fID) = nothing
+
+@inline function correct_boundary_mass_flux_bc!(
+    BC::Dirichlet, mdotf, p, pflux, psign, faces, boundary_cellsID, time, i, fID)
+    @inbounds begin
+        face = faces[fID]
+        cID = boundary_cellsID[fID]
+        (; area, delta) = face
+        flux = pflux[fID] * area / delta
+        ap = psign * (-flux)
+        mdotf[fID] += ap * (p[cID] - BC.value)
+    end
+    nothing
+end
+
+@inline function correct_boundary_mass_flux_bc!(
+    BC::DirichletFunction, mdotf, p, pflux, psign, faces, boundary_cellsID, time, i, fID)
+    @inbounds begin
+        face = faces[fID]
+        cID = boundary_cellsID[fID]
+        (; area, delta, centre) = face
+        flux = pflux[fID] * area / delta
+        ap = psign * (-flux)
+        value = BC.value(centre, time, i)
+        mdotf[fID] += ap * (p[cID] - value)
+    end
+    nothing
+end
+
+@inline function correct_boundary_mass_flux_bc!(
+    BC::Neumann, mdotf, p, pflux, psign, faces, boundary_cellsID, time, i, fID)
+    @inbounds begin
+        face = faces[fID]
+        mdotf[fID] -= pflux[fID] * face.area * BC.value
+    end
+    nothing
 end

--- a/src/UNV2/UNV2_1_loader.jl
+++ b/src/UNV2/UNV2_1_loader.jl
@@ -12,7 +12,7 @@ function read_UNV2(meshFile, TI, TF)
     index = 0
     vertexCount = 0
     vertices = TI[]
-    newBoundary = UNV2.BoundaryLoader(0)
+    newBoundary = UNV2.BoundaryLoader(zero(TI))
     currentBC = 0
     
     @inbounds for (indx, line) in enumerate(eachline(meshFile))
@@ -98,11 +98,11 @@ function read_UNV2(meshFile, TI, TF)
         # Read boundary cells
         if processDataset2467
             if typeof(tryparse(TI, sline[1]))!= Nothing && tryparse(Int32, sline[2]) == 0
-                newBoundary = UNV2.BoundaryLoader(0)
+                newBoundary = UNV2.BoundaryLoader(zero(TI))
                 push!(boundaryElements, newBoundary)
                 # currentBC = tryparse(TI, sline[1])
                 currentBC += 1
-                boundaryElements[currentBC].groupNumber = currentBC 
+                boundaryElements[currentBC].groupNumber = TI(currentBC)
                 continue
             end
             if typeof(tryparse(TI, sline[1]))== Nothing

--- a/src/UNV2/UNV2_2_geometry.jl
+++ b/src/UNV2/UNV2_2_geometry.jl
@@ -61,9 +61,9 @@ function internal_face_properties!(mesh::Mesh2{I,F}) where {I,F}
         
         # Calculate normal and check direction (from owner1 to owner2)
         unit_tangent = tangent/area
-        normal = unit_tangent × UnitVectors().k
+        normal = unit_tangent × SVector{3, F}(0, 0, 1)
         if C1C2⋅normal < zero(F)
-            normal = -1.0*normal
+            normal = -normal
         end
 
         # Calculate delta and interpolation weight
@@ -94,7 +94,7 @@ function boundary_face_properties!(mesh::Mesh2{I,F}) where {I,F}
             tangent = p2 - p1
             area = norm(tangent)
             unit_tangent = tangent/area
-            normal = unit_tangent × UnitVectors().k
+            normal = unit_tangent × SVector{3, F}(0, 0, 1)
 
             # perform normal direction check
             F1 = face.centre
@@ -102,7 +102,7 @@ function boundary_face_properties!(mesh::Mesh2{I,F}) where {I,F}
             C1F1 = F1 - C1 # distance vector from face centre to cell1 
 
             if C1F1⋅normal < zero(F)
-                normal = -1.0*normal
+                normal = -normal
             end
 
             # calculate weight, delta and e 
@@ -176,7 +176,7 @@ function cell_properties!(mesh::Mesh2{I,F}) where {I,F}
         
         # --- C. Update the Cell Array ---
         cell = @set cell.centre = true_centre
-        cell = @set cell.volume = 0.5 * volume
+        cell = @set cell.volume = F(0.5) * volume
         cells[celli] = cell
     end
 end

--- a/src/UNV2/UNV2_3_builder.jl
+++ b/src/UNV2/UNV2_3_builder.jl
@@ -36,6 +36,7 @@ function UNV2D_mesh(meshFile; scale=1, integer_type=Int64, float_type=Float64)
     # mesh = Mesh.FullMesh(nodes, faces, cells, boundaries)
 
     mesh = update_mesh_format(mesh, integer_type, float_type)
+    Mesh.validate_single_precision_mesh(mesh; source="UNV2D_mesh")
     end
     println("Done! Execution time: ", @sprintf "%.6f" stats.time)
     println("Mesh ready!")
@@ -94,15 +95,15 @@ end
 
 # GENERATION FUNCTIONS
 
-function generate_nodes(first_element, elements, points::Vector{Point{TF}}) where TF
-   nodes = Node{Int64, TF}[]
+function generate_nodes(first_element, elements::Vector{Element{TI}}, points::Vector{Point{TF}}) where {TI, TF}
+   nodes = Node{TI, TF}[]
    @inbounds for i ∈ 1:length(points)
        point = points[i].xyz
-       push!(nodes, Node(point))
+       push!(nodes, Node(point, TI[]))
    end
-   cellID = 0 # counter for cells
+   cellID = zero(TI) # counter for cells
    @inbounds for i ∈ first_element:length(elements) 
-           cellID += 1
+           cellID += one(TI)
            @inbounds for nodeID ∈ elements[i].vertices
                push!(nodes[nodeID].neighbourCells, cellID)
            end

--- a/src/UNV3/UNV3_1_reader.jl
+++ b/src/UNV3/UNV3_1_reader.jl
@@ -75,12 +75,12 @@ function read_UNV3(unv_mesh; scale=1.0, integer::Type{I}=Int64, float::Type{F}=F
                     
                     # 1. Edges (Counted strictly for global ID offsetting)
                     if num_nodes == 2 || elem_type == 11
-                        edge_counter += 1
+                        edge_counter += one(I)
                         readline(io) # Consume the edge nodes line
                         
                     # 2. Triangles (41) and Quadrilaterals (44)
                     elseif (elem_type == 41 && num_nodes == 3) || (elem_type == 44 && num_nodes == 4)
-                        face_counter += 1
+                        face_counter += one(I)
                         if element_id - edge_counter != face_counter
                             throw(ArgumentError("Face Index in UNV file are not in order! At UNV index = $element_id"))
                         end
@@ -96,7 +96,7 @@ function read_UNV3(unv_mesh; scale=1.0, integer::Type{I}=Int64, float::Type{F}=F
                         
                     # 3. Cells: Tetrahedra (111), Hexahedra (115), Prisms/Wedges (112)
                     elseif elem_type == 111 || elem_type == 115 || elem_type == 112
-                        cell_counter += 1
+                        cell_counter += one(I)
                         if element_id - face_counter - edge_counter != cell_counter
                             throw(ArgumentError("Cell Index in UNV file are not in order! At UNV index = $element_id"))
                         end
@@ -120,7 +120,7 @@ function read_UNV3(unv_mesh; scale=1.0, integer::Type{I}=Int64, float::Type{F}=F
             elseif dataset_id == "2467"
                 # Group Name detected (single non-numeric string)
                 if n_tokens == 1 && tryparse(I, sline_buffer[1]) === nothing
-                    currentBoundary += 1
+                    currentBoundary += one(I)
                     new_boundary = BoundaryElement(I(0))
                     new_boundary.index = I(currentBoundary)
                     new_boundary.name = String(sline_buffer[1])

--- a/src/UNV3/UNV3_2_builder.jl
+++ b/src/UNV3/UNV3_2_builder.jl
@@ -39,6 +39,7 @@ function UNV3D_mesh(unv_mesh; scale=1.0, integer_type=Int64, float_type=Float64)
     t_build = @elapsed begin
         mesh = _build_UNV3D_mesh_core(points, efaces, cells_UNV, boundaryElements, integer_type, float_type)
     end
+    Mesh.validate_single_precision_mesh(mesh; source="UNV3D_mesh")
     
     @info "Mesh constructed in $(round(t_build, digits=3)) seconds."
     @info "Mesh entities: $(length(mesh.nodes)) nodes | $(length(mesh.faces)) faces | $(length(mesh.cells)) cells."

--- a/test/test_DILU.jl
+++ b/test/test_DILU.jl
@@ -38,3 +38,10 @@ XCALibre.Solve.backward_substitution!(xDILU, P.storage, yDILU)
 xLDIV = zeros(n)
 XCALibre.Solve.ldiv!(xLDIV, P.storage, b)
 @test xLDIV ≈ x
+
+Acsr32 = sparsecsr([1, 2], [1, 2], Float32[2, 3], 2, 2)
+P_jacobi = XCALibre.Solve.Preconditioner{Jacobi}(Acsr32)
+P_norm_diagonal = XCALibre.Solve.Preconditioner{NormDiagonal}(Acsr32)
+
+@test eltype(P_jacobi.storage) === Float32
+@test eltype(P_norm_diagonal.storage) === Float32

--- a/test/test_mesh_conversion.jl
+++ b/test/test_mesh_conversion.jl
@@ -1,5 +1,29 @@
 test_grids_dir = pkgdir(XCALibre, "test", "grids")
 
+function test_mesh_precision(mesh, integer_type, float_type)
+    @test eltype(mesh.get_int) === integer_type
+    @test eltype(mesh.get_float) === float_type
+    @test eltype(mesh.cell_nodes) === integer_type
+    @test eltype(mesh.cell_faces) === integer_type
+    @test eltype(mesh.cell_neighbours) === integer_type
+    @test eltype(mesh.cell_nsign) === integer_type
+    @test eltype(mesh.face_nodes) === integer_type
+    @test eltype(mesh.node_cells) === integer_type
+    @test eltype(mesh.boundary_cellsID) === integer_type
+    @test eltype(mesh.cells[1].nodes_range) === integer_type
+    @test eltype(mesh.cells[1].faces_range) === integer_type
+    @test eltype(mesh.cells[1].centre) === float_type
+    @test typeof(mesh.cells[1].volume) === float_type
+    @test eltype(mesh.faces[1].nodes_range) === integer_type
+    @test eltype(mesh.faces[1].ownerCells) === integer_type
+    @test eltype(mesh.faces[1].centre) === float_type
+    @test eltype(mesh.faces[1].normal) === float_type
+    @test typeof(mesh.faces[1].area) === float_type
+    @test eltype(mesh.boundaries[1].IDs_range) === integer_type
+    @test eltype(mesh.nodes[1].coords) === float_type
+    @test eltype(mesh.nodes[1].cells_range) === integer_type
+end
+
 # test tri mesh
 meshFile = joinpath(test_grids_dir, "trig40.unv")
 mesh = UNV2D_mesh(meshFile, scale=0.001)
@@ -34,3 +58,46 @@ outputTest_FOAM3D = String(take!(msg))
 
 # Test 3D UNV and FOAM meshes are equal
 @test outputTest_UNV3D == outputTest_FOAM3D
+
+precision_cases = (
+    (Int32, Float32),
+    (Int64, Float32),
+    (Int32, Float64),
+)
+
+mesh_converters = (
+    ("UNV2D", UNV2D_mesh, joinpath(test_grids_dir, "quad40.unv")),
+    ("UNV3D", UNV3D_mesh, joinpath(test_grids_dir, "OF_cavity_hex", "cavity_hex.unv")),
+    ("FOAM3D", FOAM3D_mesh, joinpath(test_grids_dir, "OF_cavity_hex", "polyMesh")),
+)
+
+for (name, converter, meshFile) in mesh_converters
+    @testset "$name precision options" begin
+        for (integer_type, float_type) in precision_cases
+            mesh = converter(
+                meshFile;
+                scale=float_type(0.001),
+                integer_type=integer_type,
+                float_type=float_type,
+            )
+            test_mesh_precision(mesh, integer_type, float_type)
+        end
+    end
+end
+
+@testset "single precision mesh validation" begin
+    mesh = FOAM3D_mesh(
+        joinpath(test_grids_dir, "OF_cavity_hex", "polyMesh");
+        scale=Float32(0.001),
+        integer_type=Int32,
+        float_type=Float32,
+    )
+    cell = mesh.cells[1]
+    mesh.cells[1] = typeof(cell)(
+        cell.centre,
+        -abs(cell.volume),
+        cell.nodes_range,
+        cell.faces_range,
+    )
+    @test_throws ArgumentError XCALibre.Mesh.validate_single_precision_mesh(mesh; source="test")
+end


### PR DESCRIPTION
- Preserve requested mesh integer and floating-point types during UNV/FOAM conversion.
- Keep discretisation, boundary, turbulence, and solver paths type-stable for Float32 meshes.
- Add correction for pressure boundary mass-flux updates 
- Revert change made in #120 where update for the eddy viscosity only added molecular viscosity 
- add regression coverage for mesh/preconditioner precision.