### PR TITLE
Multiphase Solver - VOF Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ unv_sample_meshes/*
 *.foam
 [0-9]*/
 constant/
+
+DATA_FOR_DISSERTATION/*
+*.jld2
+VOF_cases/
+test/eos_comparison/
+test/mixture_testing/
+test/HeatFlux
+test/prep_heatflux.jl
+test/HeatFlux_1MPa.jl
+test/HeatFlux.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,109 @@
 The format used for this `changelog` is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Notice that until the package reaches version `v1.0.0` minor releases are likely to be `breaking`. Starting from version `v0.3.1` breaking changes will be recorded here. 
 
+## Version [v0.5.3] - 2026-03-05
+
+### Added
+*  Added optional adaptive time stepping based on Courant number control (`AdaptiveTimeStepping`) [#98](@ref)
+* Added runtime calculation of Q-criterion [#107]
+*  Added explicit Godunov-type compressible solver (`godunov!`) for supersonic flows using Rusanov (local Lax-Friedrichs) and HLLC flux schemes with first and second order spatial reconstruction (MinMod, VanLeer, Superbee limiters) and adaptive CFL-based time stepping [#112](@ref)
+*  Added experimental incompressible steady MFR solver [#114](@ref)
+*  Added runtime probe extraction [#115](@ref)
+*  Added initialisation logic for new Multiphase solver user-level API [#117](@ref)
+*  New Eulerian Thin Film model solver (2D only) [#120](@ref)
+*  Added `setField_Expression!` to `SetFields` utility to initialise function-based fields. [#124](@ref)
+*  Added VanLeer, upwind, and gradient interpolation schemes for scalar and vector face fields [#124](@ref)
+*  Added multiphase solver (VOF model only) with two supporting functionality tests [#127](@ref)
+
+
+### Fixed
+* Add implementation of `Periodic` boundaries to handle the implicit source term - fixes operation of models that use `Si` terms [#95](@ref)
+* Fixed implementation of implicit boundaries in [#96](@ref) which where missing atomics [#100](@ref)
+* Fixed calculation of the residuals to use the relative residual norm, norm(b - Ax)/norm(b), the numerator in this expression was calculated incorrectly previously, giving a 1/sqrt(n) relation (where n is the number of cells in the grid). whilst the operation of the solvers remains the same, user may find that convergence criteria may need to be increased (specially for larger grids)[#102](@ref)
+* UNV2: Fix calculation of cell volumes and centroid for boundary cells was incorrect and missing boundary face contributions (only for 2D UNV meshes)[#106](@ref)
+* Fixed implementation of k-omega LKE transition model and how wall distance field is calculated to ensure it is GPU compatible [#109](@ref)
+  
+### Changed
+* Improved stability of `Periodic` boundaries by making the implementation fully implicit [#96](@ref)
+* 4x speed improvement for the method `construct_periodic` [#97](@ref)
+* +50x speed improvement for the method `construct_periodic` and also more robust algorithm used [#100](@ref)
+* Implementation to correct mass flux uses matrix coefficients directly for better stability when using periodic boundary conditions [#100](@ref)
+* New method to enforce matrix symmetry of scalar model equations when the only term is a laplacian [#100](@ref)
+* Change calculation of face interpolation weights to use face normal aligned weights, this is more physical than the current method using face-based distances (in preparation for formal support for non-orthogonality correction)[#101](@ref)
+* 20x improvement loading and processing 3D UNV mesh files [#106](@ref)
+
+### Breaking
+* No breaking changes
+
+### Deprecated
+* No functions deprecated
+
+### Removed
+* No functionality has been removed
+
+## Version [v0.5.2] - 2025-01-16
+
+### Added
+*  Initial support for mixed precision (UNV meshes only) [#67](@ref)
+*  New solver for simulating conduction in solids [#65](@ref)
+*  New LES turbulent kinetic energy one equation model (`KEquation`) [#71](@ref)
+*  Surface tension model for fluids [#72](@ref)
+*  High fidelity viscosity models for H2 and N2 [#72](@ref)
+*  High fidelity thermal conductivity models for H2 and N2 [#72](@ref)
+*  `SetFields` utility that allows to set a field to desired value within a box / circle / sphere [#73](@ref)
+*  Helmholtz Energy equation of state and supporting framework for it for H2 and N2 [#75](@ref)
+*  `FieldAverage` and `FieldRMS` of Vector and Scalar fields [#78]
+*  Added `RotatingWall` velocity boundary condition [#81](@ref)
+*  Added `KOmegaSST` turbulence model [#82](@ref)
+*  Added capability to write out TensorFields to .vtk/vtu including Reynolds Stress Tensor [#84](@ref)
+*  Added capablity to write out TensorFields to .vtk/vtu including Reynolds Stress Tensor [#87](@ref)
+*  Extended `DirichLetFunction` to accept functions defining boundary condition for `ScalarFields` [#89](@ref)
+*  Implemented `CrankNicolson` time scheme (second order implicit-explicit) [#90](@ref)
+
+
+### Fixed
+* The `UNV3D_mesh` reader has been updated to ensure that the ordering of face nodes is determined in a more robust manner. This resolves some issues when loading a `UNV` mesh that is later used to store simulation results in the `OpenFOAM` format [#64](@ref)
+* In the construction of a `Physics` object, the `boundary_map` function returned a `boundary_info` struct which was incorrectly using an abstract type `Integer`. This resulted in a failure to convert a `Physics` object to the cpu and back to the gpu [#67](@ref)
+* Fixed calculation of interpolation weights for 2D UNV grids [#68](@ref)
+* Added method for boundary interpolation when using `LUST` and `DirichletFunction`[#68](@ref)
+* Fixed `boundary_interpolation` for `DirichletFunction` when a function is passed [#79](@ref)
+  
+### Changed
+* The constructors for `ScalarField` and `FaceScalarField` now include a `store_mesh` keyword argument to request a reference of the mesh to be stored (default) or not (setting `store_mesh=false`). This can be used to not include references to the mesh for each field in `VectorFields` and `TensorFields`. This has improved compile times and decreased simulation times (particularly on the GPU - perhaps due to freeing registers used to carry unnecessary type information) [#69](@ref)
+* Internally, the calculation of interpolation weights and other geometric properties are calculated using the same function (defined in the `Mesh` module) [#69](@ref)
+* The default discretisation for laplacian terms uses the over-relaxed formulation by default. This will have no effect on orthogonal grids, but tends to be more robust in complex geometries at the expense of accuracy, which can be recovered by adding additional orthogonal correction loops (using the key word argument `ncorrectors` in the `run!` function) [#73](@ref)
+* Cleaned code for all solvers and improved stability of incompressible solver by removing the update of the mass flow based on the velocity field from the previous iteration. The mass flow is now corrected directly from the latest pressure solution [#76](@ref)
+
+### Breaking
+* No breaking changes
+
+### Deprecated
+* No functions deprecated
+
+### Removed
+* No functionality has been removed
+
+## Version [v0.5.1] - 2025-07-03
+
+### Added
+*  New `Empty` boundary condition allowing 2D simulations with OpenFOAM 2D-compatible grids[#63](@ref)
+*  Tests for the `Smagorinsky` LES model have been included [#63](@ref)
+
+### Fixed
+* No fixes included
+  
+### Changed
+* Transient simulation results for `VTK` and `VTU` files use the format `time_<iteration>` [#63](@ref)
+
+### Breaking
+* No breaking changes
+
+### Deprecated
+* No functions deprecated
+
+### Removed
+* No functionality has been removed
+
 ## Version [v0.5.0] - 2025-06-28
 
 ### Added

--- a/src/Discretise/Discretise_1_schemes.jl
+++ b/src/Discretise/Discretise_1_schemes.jl
@@ -16,7 +16,7 @@ cIndex - Index of the cell based on sparse matrix. Use to index "nzval_array"
     0.0, 0.0 # add types if this approach works
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Time{SteadyState}}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
+    term::Operator{F,P,I,Time{SteadyState}}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P,I} = begin
     0.0, 0.0
 end
 
@@ -24,17 +24,55 @@ end
 @inline function scheme!(
     term::Operator{F,P,I,Time{Euler}}, 
     nzval_array, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime)  where {F,P,I}
-    # nothing
     0.0, 0.0 # add types if this approach works
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Time{Euler}}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
+    term::Operator{F,P,I,Time{Euler}}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P<:ScalarField,I} = begin
         volume = cell.volume
-        vol_rdt = volume/runtime.dt
+        vol_rdt = volume/runtime.dt[1]
+        rho = term.flux[cID]
+        
+        ac = rho * vol_rdt
+        b = rho_prev[cID]*prev[cID]*vol_rdt # Careful with non U_eqn (e.g. T eqn.)
+        return ac, b
+end
+@inline scheme_source!(
+    term::Operator{F,P,I,Time{Euler}}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P<:VectorField,I} = begin # Special case for U_eqn (rho)
+        volume = cell.volume
+        vol_rdt = volume/runtime.dt[1]
+        rho = term.flux[cID]
         
         # Increment sparse and b arrays 
-        ac = vol_rdt
-        b = prev[cID]*vol_rdt
+        ac = rho * vol_rdt
+        b = rho_prev[cID]*prev[cID]*vol_rdt
+        return ac, b
+end
+
+## Crank-Nicholson
+@inline function scheme!(
+    term::Operator{F,P,I,Time{CrankNicolson}}, 
+    nzval_array, cell, face,  cellN, ns, cIndex, nIndex, fID, prev, runtime)  where {F,P,I}
+
+    0.0, 0.0 # add types if this approach works
+end
+@inline scheme_source!(
+    term::Operator{F,P,I,Time{CrankNicolson}}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P<:ScalarField,I} = begin
+        volume = cell.volume
+        vol_rdt = volume/runtime.dt[1]
+        rho = term.flux[cID]
+        
+        ac = rho * vol_rdt
+        b = rho_prev[cID]*prev[cID]*vol_rdt # Careful with non U_eqn (e.g. T eqn.)
+        return ac, b
+end
+@inline scheme_source!(
+    term::Operator{F,P,I,Time{CrankNicolson}}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P<:VectorField,I} = begin
+        volume = cell.volume
+        vol_rdt = volume/runtime.dt[1]
+        rho = term.flux[cID]
+        
+        ac = rho * vol_rdt
+        b = rho_prev[cID]*prev[cID]*vol_rdt
         return ac, b
 end
 
@@ -65,7 +103,7 @@ end
     return ac, an
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Laplacian{Linear}}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
+    term::Operator{F,P,I,Laplacian{Linear}}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P,I} = begin
     0.0, 0.0
 end
 
@@ -93,7 +131,7 @@ end
     return ac, an
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Divergence{Linear}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{Linear}}, cell, cID, cIndex, prev, runtime, rho_prev) where {F,P,I} = begin
     0.0, 0.0
 end
 
@@ -109,7 +147,7 @@ end
     return ac, an
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Divergence{Upwind}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{Upwind}}, cell, cID, cIndex, prev, runtime, rho_prev) where {F,P,I} = begin
     0.0, 0.0
 end
 
@@ -138,7 +176,7 @@ end
     return ac, an
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Divergence{LUST}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{LUST}}, cell, cID, cIndex, prev, runtime, rho_prev) where {F,P,I} = begin
     0.0, 0.0
 end
 
@@ -155,7 +193,7 @@ end
     return ac, an
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Divergence{BoundedUpwind}}, cell, cID, cIndex, prev, runtime) where {F,P,I} = begin
+    term::Operator{F,P,I,Divergence{BoundedUpwind}}, cell, cID, cIndex, prev, runtime, rho_prev) where {F,P,I} = begin
     0.0, 0.0
 end
 
@@ -168,7 +206,7 @@ end
     0.0, 0.0
 end
 @inline scheme_source!(
-    term::Operator{F,P,I,Si}, cell, cID, cIndex, prev, runtime)  where {F,P,I} = begin
+    term::Operator{F,P,I,Si}, cell, cID, cIndex, prev, runtime, rho_prev)  where {F,P,I} = begin
     
     # Retrieve and calculate flux for cell 
     flux = term.sign*term.flux[cID]*cell.volume # indexed with cID

--- a/src/Discretise/Discretise_2_generated_distretisation.jl
+++ b/src/Discretise/Discretise_2_generated_distretisation.jl
@@ -1,7 +1,7 @@
 export discretise!, update_equation!
 
 function discretise!(
-    eqn::ModelEquation{T,M,E,S,P}, prev, config) where {T<:VectorModel,M,E,S,P}
+    eqn::ModelEquation{T,M,E,S,P}, prev, config, rho_prev) where {T<:VectorModel,M,E,S,P}
     (; hardware, runtime) = config
     (; backend, workgroup) = hardware
 
@@ -24,14 +24,14 @@ function discretise!(
     # Call discretise kernel
     ndrange = length(mesh.cells)
     kernel! = _discretise_vector_model!(_setup(backend, workgroup, ndrange)...)
-    kernel!(model, model.terms, model.sources, mesh, nzval0, nzval, colval, rowptr, bx, by, bz, prev, runtime)
+    kernel!(model, model.terms, model.sources, mesh, nzval0, nzval, colval, rowptr, bx, by, bz, prev, runtime, rho_prev)
     # # KernelAbstractions.synchronize(backend)
 end
 
 # @kernel function _discretise_vector_model!(
 #     model::Model{TN,SN,T,S}, terms, sources, mesh, nzval0::AbstractArray{F}, nzval, colval, rowptr, bx, by, bz, prev, runtime) where {TN,SN,T,S,F}
 @kernel function _discretise_vector_model!(
-    model::Model{TN,SN,T,S}, terms::TERMS, sources::SRCS, mesh, nzval0::AbstractArray{F}, nzval, colval, rowptr, bx, by, bz, prev, runtime) where {TN,SN,T,S,F,TERMS,SRCS}
+    model::Model{TN,SN,T,S}, terms::TERMS, sources::SRCS, mesh, nzval0::AbstractArray{F}, nzval, colval, rowptr, bx, by, bz, prev, runtime, rho_prev) where {TN,SN,T,S,F,TERMS,SRCS}
     i = @index(Global)
     # Extract mesh fields for kernel
     (; faces, cells, cell_faces, cell_neighbours, cell_nsign) = mesh
@@ -68,7 +68,7 @@ end
 
         
         # Call scheme source generated function NEEDS UPDATING!
-        ac, bx1, by1, bz1 = _scheme_source!(model, terms, cell, i, cIndex, prev, runtime)
+        ac, bx1, by1, bz1 = _scheme_source!(model, terms, cell, i, cIndex, prev, runtime, rho_prev)
         
         nzval0[cIndex] = ac_sum + ac
 
@@ -81,7 +81,7 @@ end
 end
 
 function discretise!(
-    eqn::ModelEquation{T,M,E,S,P}, prev, config) where {T<:ScalarModel,M,E,S,P}
+    eqn::ModelEquation{T,M,E,S,P}, prev, config, rho_prev) where {T<:ScalarModel,M,E,S,P}
 
     (; hardware, runtime) = config
     (; backend, workgroup) = hardware
@@ -103,7 +103,7 @@ function discretise!(
     # Call discretise kernel
     ndrange = length(mesh.cells)
     kernel! = _discretise_scalar_model!(_setup(backend, workgroup, ndrange)...)
-    kernel!(model, model.terms, model.sources, mesh, nzval, colval, rowptr, b, prev, runtime)
+    kernel!(model, model.terms, model.sources, mesh, nzval, colval, rowptr, b, prev, runtime, rho_prev)
     # # KernelAbstractions.synchronize(backend)
 end
 
@@ -111,7 +111,7 @@ end
 # @kernel function _discretise_scalar_model!(
 #     model::Model{TN,SN,T,S}, terms, sources, mesh, nzval::AbstractArray{F}, colval, rowptr, b, prev, runtime) where {TN,SN,T,S,F}
 @kernel function _discretise_scalar_model!(
-    model::Model{TN,SN,T,S}, terms::TERMS, sources::SRCS, mesh, nzval::AbstractArray{F}, colval, rowptr, b, prev, runtime) where {TN,SN,T,S,F,TERMS,SRCS}
+    model::Model{TN,SN,T,S}, terms::TERMS, sources::SRCS, mesh, nzval::AbstractArray{F}, colval, rowptr, b, prev, runtime, rho_prev) where {TN,SN,T,S,F,TERMS,SRCS}
 
     i = @index(Global)
     # Extract mesh fields for kernel
@@ -145,7 +145,7 @@ end
         end
         
         # Call scheme source generated function
-        ac, b1 = _scheme_source!(model, terms, cell, i, cIndex, prev, runtime)
+        ac, b1 = _scheme_source!(model, terms, cell, i, cIndex, prev, runtime, rho_prev)
         nzval[cIndex] = ac_sum + ac
 
         # Call sources generated function
@@ -181,7 +181,7 @@ return_quote(x, t) = :(nothing)
 end
 
 # Scheme source generated function definition
-@generated function _scheme_source!(model::Model{TN,SN,T,S}, terms::TERMS, cell, cID, cIndex, prev, runtime) where {TN,SN,T,S,TERMS}
+@generated function _scheme_source!(model::Model{TN,SN,T,S}, terms::TERMS, cell, cID, cIndex, prev, runtime, rho_prev) where {TN,SN,T,S,TERMS}
     # Allocate expression array to store scheme_source function
     out = Expr(:block)
     
@@ -189,7 +189,7 @@ end
     if S.parameters[1].parameters[1] <: AbstractScalarField
         for t in 1:TN
             function_call_scheme_source = quote
-                ac, b = scheme_source!(terms[$t], cell, cID, cIndex, prev, runtime)
+                ac, b = scheme_source!(terms[$t], cell, cID, cIndex, prev, runtime, rho_prev)
                 AC += ac
                 B += b
             end
@@ -206,9 +206,9 @@ end
     elseif S.parameters[1].parameters[1] <: AbstractVectorField
         for t in 1:TN
             function_call_scheme_source = quote
-                ac, bx = scheme_source!(terms[$t], cell, cID, cIndex, prev.x, runtime)
-                ac, by = scheme_source!(terms[$t], cell, cID, cIndex, prev.y, runtime)
-                ac, bz = scheme_source!(terms[$t], cell, cID, cIndex, prev.z, runtime)
+                ac, bx = scheme_source!(terms[$t], cell, cID, cIndex, prev.x, runtime, rho_prev)
+                ac, by = scheme_source!(terms[$t], cell, cID, cIndex, prev.y, runtime, rho_prev)
+                ac, bz = scheme_source!(terms[$t], cell, cID, cIndex, prev.z, runtime, rho_prev)
                 AC += ac # assuming ac's for all directions are equal
                 BX += bx
                 BY += by

--- a/src/ModelPhysics/Turbulence/RANS_laminar.jl
+++ b/src/ModelPhysics/Turbulence/RANS_laminar.jl
@@ -102,8 +102,21 @@ function save_output(model::Physics{T,F,M,Tu,E,D,BI}, outputWriter, iteration, c
     write_results(iteration, model.domain, outputWriter, config.boundaries, args...)
 end
 
-function save_output(model::Physics{T,F,M,Tu,E,D,BI}, outputWriter, iteration, config
-    ) where {T,F,M,Tu<:Laminar,E<:Nothing,D,BI}
+function save_output(model::Physics{T,F,SO,M,Tu,E,D,BI}, outputWriter, iteration, time, config
+    ) where {T,F<:Multiphase,SO,M,Tu<:Laminar,E<:Nothing,D,BI}
+
+    args = (
+        ("U", model.momentum.U), 
+        ("p", model.momentum.p),
+        ("alpha", model.fluid.alpha),
+        ("rho", model.fluid.rho),
+        ("p_rgh", model.fluid.p_rgh)
+    )
+    write_results(iteration, time, model.domain, outputWriter, config.boundaries, args...)
+end
+
+function save_output(model::Physics{T,F,SO,M,Tu,E,D,BI}, outputWriter, iteration, time, config
+    ) where {T,F,SO,M,Tu<:Laminar,E<:Nothing,D,BI}
     args = (
         ("U", model.momentum.U), 
         ("p", model.momentum.p),

--- a/src/Solve/Solve_1_api.jl
+++ b/src/Solve/Solve_1_api.jl
@@ -75,7 +75,49 @@ SolverSetup(;
         SolverSetup{float_type,I,S1,S2,PT}(
             solver, smoother,preconditioner, convergence, relax, limit,itmax, atol,rtol)
 
-struct Runtime{I<:Integer,F<:AbstractFloat}
+struct AdaptiveTimeStepping{F<:AbstractFloat}
+    maxCo::F
+    maxAlphaCo::F
+    minShrink::F
+    maxGrow::F
+end
+Adapt.@adapt_structure AdaptiveTimeStepping
+
+"""
+    AdaptiveTimeStepping(; 
+        # keyword arguments
+
+        maxCo=0.75,
+        maxAlphaCo=0.5,
+        minShrink=0.1,
+        maxGrow=1.2
+    )
+
+Constructs an `AdaptiveTimeStepping` object used to control automatic time-step adjustment
+based on the Courant number.
+
+This struct is passed optionally to `Runtime` and enables adaptive time stepping in transient
+simulations. If not provided, a fixed time step is used.
+
+# Input arguments
+
+- `maxCo::AbstractFloat`: target maximum Courant number. The time step will be adjusted
+  such that the computed Courant number approaches this value.
+- `maxAlphaCo::AbstractFloat`: target maximum Alpha Courant number. The time step will be adjusted
+  such that the computed Courant number approaches this value.
+- `minShrink::AbstractFloat`: lower bound on the multiplicative factor applied to the
+  current time step. Prevents excessively large reductions in a single update.
+- `maxGrow::AbstractFloat`: upper bound on the multiplicative factor applied to the
+  current time step. Prevents excessive time-step growth.
+"""
+AdaptiveTimeStepping(;
+    maxCo=0.75,
+    maxAlphaCo=0.5,
+    minShrink=0.1,
+    maxGrow=1.2
+) = AdaptiveTimeStepping(float(maxCo), float(maxAlphaCo), float(minShrink), float(maxGrow))
+
+struct Runtime{I<:Integer,F<:AbstractFloat, V<:AbstractVector{F}, A<:Union{Nothing, AdaptiveTimeStepping}}
     iterations::I
     dt::F
     write_interval::I
@@ -158,10 +200,10 @@ end
 
 
 function solve_equation!(
-    eqn::ModelEquation{T,M,E,S,P}, phi, phiBCs, solversetup, config; time=nothing, ref=nothing, irelax=nothing
+    eqn::ModelEquation{T,M,E,S,P}, phi, phiBCs, solversetup, config; rho_prev=nothing, time=nothing, ref=nothing, irelax=nothing
     ) where {T<:ScalarModel,M,E,S,P}
 
-    discretise!(eqn, phi, config)       
+    discretise!(eqn, phi, config, rho_prev)       
     apply_boundary_conditions!(eqn, phiBCs, nothing, time, config)
     setReference!(eqn, ref, 1, config)
     if !isnothing(irelax)
@@ -174,12 +216,12 @@ function solve_equation!(
 end
 
 function solve_equation!(
-    psiEqn::ModelEquation{T,M,E,S,P}, psi, psiBCs, solversetup, xdir, ydir, zdir, config; time=nothing
+    psiEqn::ModelEquation{T,M,E,S,P}, psi, psiBCs, solversetup, xdir, ydir, zdir, config; rho_prev=nothing, time=nothing
     ) where {T<:VectorModel,M,E,S,P}
 
     mesh = psi.mesh
 
-    discretise!(psiEqn, psi, config)
+    discretise!(psiEqn, psi, config, rho_prev)
     update_equation!(psiEqn, config)
 
     apply_boundary_conditions!(psiEqn, psiBCs, xdir, time, config)

--- a/src/Solvers/Solvers_0_functions.jl
+++ b/src/Solvers/Solvers_0_functions.jl
@@ -283,3 +283,72 @@ end
     dx = volume^0.5
     cellsCourant[i] = umag * dt / dx
 end
+
+
+
+## ALPHA COURANT NUMBER
+
+max_alpha_courant_number!(cellsAlphaCourant, alpha, mdotf, model, config, dt) = begin
+    (; U) = model.momentum
+    (; mesh) = U
+    (; hardware, runtime) = config
+    (; backend, workgroup) = hardware
+
+    ndrange = length(cellsAlphaCourant)
+    kernel! = _max_alpha_courant_number!(_setup(backend, workgroup, ndrange)...)
+    kernel!(cellsAlphaCourant, alpha, mdotf, runtime, dt, mesh)
+    # # KernelAbstractions.synchronize(backend)
+    return maximum(cellsAlphaCourant)
+end
+
+
+@kernel function _max_alpha_courant_number!(cellsAlphaCourant, alpha, mdotf, runtime, dt, mesh)
+    i = @index(Global)
+
+    @uniform cells = mesh.cells
+    @uniform cell_faces = mesh.cell_faces
+
+    # dt = runtime.dt
+    volume = cells[i].volume
+    alphaVal = alpha[i]
+
+    nearInterfaceVal = nearInterface(alphaVal)
+    sumAbsMdotf = zero(alphaVal)
+
+    fr = cells[i].faces_range
+    @inbounds for k in fr
+        pointer = cell_faces[k]
+        # faceID = mesh.faces[pointer]
+        sumAbsMdotf += abs(mdotf[pointer])
+    end
+
+    cellsAlphaCourant[i] = dt * nearInterfaceVal * sumAbsMdotf / volume
+end
+
+@inline nearInterface(alpha) = ifelse((alpha > 0.01) & (alpha < 0.99), one(alpha), zero(alpha)) #Combines the two functions below into one
+# @inline pos0(x) = ifelse(x >= zero(x), one(x), zero(x))
+# @inline nearInterface(α) = pos0(α - 0.01) * pos0(0.99 - α)
+
+
+update_dt!(runtime::Runtime{<:Any,<:Any,<:Any,Nothing}, ::Any) = nothing
+update_dt!(runtime::Runtime{<:Any,<:Any,<:Any,Nothing}, ::Any, ::Any) = nothing
+
+function update_dt!(runtime::Runtime{<:Any,<:Any,<:Any,<:AdaptiveTimeStepping}, courant)
+    (; maxCo, maxGrow, minShrink) = runtime.adaptive
+
+    courant_factor = maxCo / (courant + eps())
+    new_dt_factor = clamp(courant_factor, minShrink, maxGrow)
+    runtime.dt .= runtime.dt .* new_dt_factor
+end
+
+function update_dt!(runtime::Runtime{<:Any,<:Any,<:Any,<:AdaptiveTimeStepping}, courant, alphaCourant)
+    (; maxCo, maxAlphaCo, maxGrow, minShrink) = runtime.adaptive
+
+    courant_factor = maxCo / (courant + eps())
+    alphaCourant_factor = maxAlphaCo / (alphaCourant + eps())
+    
+    new_dt_factor = min(courant_factor, alphaCourant_factor)
+    new_dt_factor = clamp(new_dt_factor, minShrink, maxGrow)
+
+    runtime.dt .= runtime.dt .* new_dt_factor
+end

--- a/src/Solvers/Solvers_3_solver_dispatch.jl
+++ b/src/Solvers/Solvers_3_solver_dispatch.jl
@@ -44,6 +44,67 @@ residuals.p
 """
 run!() = nothing # dummy function for providing general documentation
 
+
+run!(
+    model::Physics{T,F,SO,M,Tu,E,D,BI}, config;
+    output=VTK(), pref=nothing, ncorrectors=0, inner_loops=3
+    ) where{T,F<:Multiphase,SO,M,Tu,E,D,BI} =
+begin
+    residuals = multiphase!(
+        model, config,
+        output=output,
+        pref=pref,
+        ncorrectors=ncorrectors,
+        inner_loops=inner_loops,
+        )
+    return residuals
+end
+
+# Laplace solver (steady)
+"""
+    run!(
+        model::Physics{T,F,SO,M,Tu,E,D,BI}, config;
+        output=VTK(), pref=nothing, ncorrectors=0, inner_loops=0
+        ) where{T,F,SO<:Uniform,M,Tu,E,D,BI} = 
+    begin
+        residuals = laplace!(model, config, pref=pref)
+        return residuals
+    end
+
+    
+Top-level entry point for solving the Laplace (heat conduction) equation on `model.domain`.  
+Optionally runs in steady or transient mode and can call CryogenicConduction energy model for high fidelity (k and cp are recomputed at each iteration).
+
+
+# Input
+- `model` represents the `Physics` model defined by user.
+- `config` Configuration structure defined by user with solvers, schemes, runtime and hardware structures configuration details.
+- `output` select the format used for simulation results from `VTK()` or `OpenFOAM()` (default = `VTK()`)
+- `pref` Reference pressure value for cases that do not have a pressure defining BC. Incompressible solvers only.
+
+# Output
+
+This function returns a `NamedTuple` for accessing the residuals (e.g. `residuals.Ux`) with the following entries:
+
+    
+- `T`   - (Vector?) of temperature residuals for each iteration.
+"""
+run!(
+    model::Physics{T,F,SO,M,Tu,E,D,BI}, config; 
+    output=VTK(), pref=nothing, ncorrectors=0, inner_loops=0
+    ) where{T,F,SO,M,Tu,E<:Conduction,D,BI} = 
+begin
+    residuals = laplace!(
+        model, config, 
+        output=output,
+        pref=pref, 
+        ncorrectors=ncorrectors, 
+        inner_loops=inner_loops
+        )
+    return residuals
+end
+
+
 # Incompressible solver (steady)
 """
     run!(

--- a/src/Solvers/Solvers_5_Multiphase.jl
+++ b/src/Solvers/Solvers_5_Multiphase.jl
@@ -1,0 +1,1201 @@
+export multiphase!
+
+function multiphase!(
+    model, config;
+    output=VTK(), pref=nothing, ncorrectors=0, inner_loops=2)
+
+    residuals = setup_multiphase_solvers(
+        MULTIPHASE, model, config;
+        output=output,
+        pref=pref,
+        ncorrectors=ncorrectors,
+        inner_loops=inner_loops
+        )
+
+    return residuals
+end
+
+multiphase_extras(::VOF, mesh) = ()
+
+function multiphase_extras(::Mixture, mesh)
+    slip_momentum_term = FaceTensorField(mesh)
+    div_slip_momentum = VectorField(mesh)
+    return (slip_momentum_term, div_slip_momentum)
+end
+
+function setup_multiphase_solvers(
+    solver_variant, model, config;
+    output=VTK(), pref=nothing, ncorrectors=0, inner_loops=0
+    )
+
+    (; solvers, schemes, runtime, hardware, boundaries) = config
+
+    @info "Extracting configuration and input fields..."
+
+    (; U, p) = model.momentum
+    (; alpha, alphaf, rho, rhof, nu, nuf, p_rgh, p_rghf) = model.fluid
+
+    mp_model = model.fluid.model
+
+    phases = model.fluid.phases
+    volume_fraction = model.fluid.volume_fraction
+    main = volume_fraction
+    secondary = 3 - volume_fraction
+
+    mesh = model.domain
+
+    @info "Pre-allocating fields..."
+
+    TF = _get_float(mesh)
+    time = zero(TF)
+
+    ∇p = Grad{schemes.p_rgh.gradient}(p)
+
+    ∇p_rgh = Grad{schemes.p_rgh.gradient}(p_rgh)
+    grad!(∇p_rgh, p_rghf, p_rgh, boundaries.p_rgh, time, config)
+    limit_gradient!(schemes.p_rgh.limiter, ∇p_rgh, p_rgh, config)
+
+    mdotf = FaceScalarField(mesh)
+    rhoPhi = FaceScalarField(mesh)
+    rDf = FaceScalarField(mesh)
+    initialise!(rDf, 1.0)
+    nueff = FaceScalarField(mesh)
+    mueff = FaceScalarField(mesh)
+    divHv = ScalarField(mesh)
+
+    phi_g = VectorField(mesh)
+    phi_gf = FaceScalarField(mesh)
+
+    extra_models = multiphase_extras(mp_model, mesh)
+
+    mules = (
+        alpha_prev    = ScalarField(mesh),
+
+        div_alpha     = ScalarField(mesh),
+        div_mdotf     = ScalarField(mesh),
+
+        alpha_fluxf   = FaceScalarField(mesh),
+        alphaf_upwind = FaceScalarField(mesh),
+        alphaf_HO     = FaceScalarField(mesh),
+
+        phiLf         = FaceScalarField(mesh),
+        phiHf         = FaceScalarField(mesh),
+        phiAf         = FaceScalarField(mesh),
+
+        Pplus         = ScalarField(mesh),
+        Pminus        = ScalarField(mesh),
+
+        Qplus         = ScalarField(mesh),
+        Qminus        = ScalarField(mesh),
+
+        Rplus         = ScalarField(mesh),
+        Rminus        = ScalarField(mesh),
+
+        alphaMaxLocal = ScalarField(mesh),
+        alphaMinLocal = ScalarField(mesh),
+    )
+
+    @info "Computing fluid properties..."
+
+    blend_properties!(rho, alpha, phases[main].rho[1], phases[secondary].rho[1])
+    blend_properties!(rhof, alphaf, phases[main].rho[1], phases[secondary].rho[1])
+    blend_properties!(nuf, alphaf, phases[main].mu[1] / phases[main].rho[1], phases[secondary].mu[1] / phases[secondary].rho[1])
+    @. mueff.values = rhof.values * nueff.values
+
+    gh = model.fluid.physics_properties.gravity.gh
+    ghf = model.fluid.physics_properties.gravity.ghf
+    g = model.fluid.physics_properties.gravity.g
+
+    compute_gh!(gh, g, config)
+    compute_ghf!(ghf, g, config)
+
+    @info "Defining models..."
+
+    if typeof(mp_model) <: VOF
+
+        U_eqn = (
+            Time{schemes.U.time}(rho, U)
+            + Divergence{schemes.U.divergence}(rhoPhi, U)
+            - Laplacian{schemes.U.laplacian}(mueff, U)
+            ==
+            - Source(∇p_rgh.result)
+        ) → VectorEquation(U, boundaries.U)
+
+    elseif typeof(mp_model) <: Mixture
+
+        div_slip_momentum = extra_models[2]
+
+        U_eqn = (
+            Time{schemes.U.time}(rho, U)
+            + Divergence{schemes.U.divergence}(rhoPhi, U)
+            - Laplacian{schemes.U.laplacian}(mueff, U)
+            ==
+            - Source(∇p_rgh.result)
+            - Source(div_slip_momentum)
+        ) → VectorEquation(U, boundaries.U)
+
+    end
+
+    p_eqn = (
+        - Laplacian{schemes.p.laplacian}(rDf, p_rgh)
+        ==
+        - Source(divHv)
+    ) → ScalarEquation(p_rgh, boundaries.p_rgh)
+
+    @info "Initialising preconditioners..."
+
+    @reset U_eqn.preconditioner = set_preconditioner(solvers.U.preconditioner, U_eqn)
+    @reset p_eqn.preconditioner = set_preconditioner(solvers.p_rgh.preconditioner, p_eqn)
+
+    @info "Pre-allocating solvers..."
+
+    @reset U_eqn.solver = _workspace(solvers.U.solver, _b(U_eqn, XDir()))
+    @reset p_eqn.solver = _workspace(solvers.p_rgh.solver, _b(p_eqn))
+
+    @info "Initialising turbulence model..."
+    turbulenceModel, config = initialise(model.turbulence, model, mdotf, p_eqn, config)
+
+    residuals = solver_variant(
+        model, turbulenceModel, ∇p, ∇p_rgh, U_eqn, p_eqn,
+        mdotf, rhoPhi, gh, ghf, phi_g, phi_gf, extra_models, mules, config;
+        output=output, pref=pref,
+        ncorrectors=ncorrectors, inner_loops=inner_loops)
+
+    return residuals
+end
+
+
+
+function MULTIPHASE(
+    model, turbulenceModel, ∇p, ∇p_rgh, U_eqn, p_eqn,
+    mdotf, rhoPhi, gh, ghf, phi_g, phi_gf,
+    extra_models, mules, config;
+    output=VTK(), pref=nothing, ncorrectors=0, inner_loops=3
+    )
+
+    (; alpha_prev, div_alpha, div_mdotf, alpha_fluxf,
+       alphaf_upwind, alphaf_HO, phiLf, phiHf, phiAf,
+       Pplus, Pminus, Qplus, Qminus, Rplus, Rminus,
+       alphaMaxLocal, alphaMinLocal) = mules
+
+    (; U, p) = model.momentum
+    (; nu, nuf, rho, rhof, alpha, alphaf, p_rgh, p_rghf) = model.fluid
+    (; solvers, schemes, runtime, hardware, boundaries, postprocess) = config
+    (; iterations, write_interval) = runtime
+    (; backend) = hardware
+
+    mesh      = model.domain
+    mp_model  = model.fluid.model
+    phases    = model.fluid.phases
+    main      = model.fluid.volume_fraction
+    secondary = 3 - main
+
+    TF      = _get_float(mesh)
+    TI      = _get_int(mesh)
+    n_cells = length(mesh.cells)
+
+    @info "Allocating working memory..."
+
+    dt_cpu = zeros(TF, 1)
+    copyto!(dt_cpu, runtime.dt)
+    postprocess = convert_time_to_iterations(postprocess, model, dt_cpu[1], iterations)
+
+    mueff = get_flux(U_eqn, 3)
+    rDf   = get_flux(p_eqn, 1)
+    divHv = get_source(p_eqn, 1)
+    nueff = FaceScalarField(mesh)
+
+    outputWriter = initialise_writer(output, mesh)
+
+    gradU  = Grad{schemes.U.gradient}(U)
+    gradUT = T(gradU)
+    Uf = FaceVectorField(mesh)
+    S  = StrainRate(gradU, gradUT, U, Uf)
+
+    # Aux fields for discretisation consistency
+    ∇p_rghf_deconstructed = FaceScalarField(mesh)
+    ∇p_rghf_reconstructed = VectorField(mesh)
+    pressure_force_face   = FaceScalarField(mesh)
+
+    rho1_val = phases[main].rho[1]
+    rho2_val = phases[secondary].rho[1]
+    mu1_val  = phases[main].mu[1]
+    mu2_val  = phases[secondary].mu[1]
+
+    rho1f = FaceScalarField(mesh); initialise!(rho1f, rho1_val)
+    rho2f = FaceScalarField(mesh); initialise!(rho2f, rho2_val)
+    mu1f  = FaceScalarField(mesh); initialise!(mu1f,  mu1_val)
+    mu2f  = FaceScalarField(mesh); initialise!(mu2f,  mu2_val)
+
+    ∇alpha  = Grad{schemes.alpha.gradient}(alpha)
+    ∇alphaf = FaceVectorField(mesh)
+
+    if typeof(mp_model) <: Mixture
+        slip_momentum_term, div_slip_momentum = extra_models
+        Sc_t     = 0.7
+        g_vec    = model.fluid.physics_properties.gravity.g
+        diameter = mp_model.diameter
+        tau_d    = (rho2_val * diameter^2) / (18.0 * mu1_val + eps())
+        tau_d_field = ScalarField(mesh); initialise!(tau_d_field, tau_d)
+
+        U_prev = VectorField(mesh)
+        DUmDt  = VectorField(mesh)
+        Ur     = VectorField(mesh)
+        Urf    = FaceVectorField(mesh)
+        Urdotf = FaceScalarField(mesh)
+        ∇U     = Grad{schemes.U.gradient}(U)
+    end
+
+    if typeof(mp_model) <: VOF
+        sigma   = mp_model.sigma
+        C_alpha = mp_model.cAlpha
+
+        phirf          = FaceScalarField(mesh)
+        nhatf_prep     = FaceVectorField(mesh)
+        kappa          = ScalarField(mesh)
+        kappaf         = FaceScalarField(mesh)
+        grad_alpha_mag = ScalarField(mesh)
+    end
+
+    Hv       = VectorField(mesh)
+    rD       = ScalarField(mesh)
+    rho_prev = ScalarField(mesh)
+    prev     = KernelAbstractions.zeros(backend, TF, n_cells)
+
+    R_ux    = ones(TF, iterations)
+    R_uy    = ones(TF, iterations)
+    R_uz    = ones(TF, iterations)
+    R_p     = ones(TF, iterations)
+    R_alpha = ones(TF, iterations)
+    cellsCourant      = KernelAbstractions.zeros(backend, TF, n_cells)
+    cellsAlphaCourant = KernelAbstractions.zeros(backend, TF, n_cells)
+
+    time = zero(TF)
+    interpolate!(Uf, U, config)
+    correct_boundaries!(Uf, U, boundaries.U, time, config)
+    flux!(mdotf, Uf, config)
+    @. rhoPhi.values = mdotf.values * rhof.values
+    update_nueff!(nueff, nuf, model.turbulence, config)
+    @. mueff.values  = rhof.values * nueff.values
+
+    xdir, ydir, zdir = XDir(), YDir(), ZDir()
+
+    @info "Starting multiphase solver..."
+
+    progress = Progress(iterations; dt=1.0, showspeed=true)
+
+    @time for iteration ∈ 1:iterations
+
+        copyto!(dt_cpu, config.runtime.dt)
+        time += dt_cpu[1]
+
+        @. rho_prev.values = rho.values
+
+        # Bounded alpha eqn. transport via MULES
+        advance_alpha!(model, mp_model, ∇alpha, ∇alphaf, mdotf,
+                       alpha_prev, alphaf_upwind, alphaf_HO, phirf, phiLf, phiHf, phiAf,
+                       alpha_fluxf, div_alpha, div_mdotf,
+                       Pplus, Pminus, Qplus, Qminus, Rplus, Rminus,
+                       alphaMaxLocal, alphaMinLocal, C_alpha, dt_cpu[1], time, config)
+        ralpha = zero(TF)
+
+        # Mixture property update from the new alpha
+        update_mixture_properties!(model, alpha_fluxf, mdotf, rhoPhi, nueff, mueff,
+                                   rho1_val, rho2_val, mu1_val, mu2_val, config)
+
+        # Interface curvature for surface tension (VOF only)
+        if typeof(mp_model) <: VOF
+            update_curvature!(model, ∇alpha, ∇alphaf, nhatf_prep, kappa, kappaf,
+                              grad_alpha_mag, time, config)
+        end
+
+        well_balanced_pressure_grad!(
+            ∇p_rgh.result, pressure_force_face,
+            p_rgh, rho, ghf, mesh, config;
+            sigma=sigma, kappaf=kappaf, alpha=alpha)
+
+        rx, ry, rz = solve_equation!(
+            U_eqn, U, boundaries.U, solvers.U, xdir, ydir, zdir, config; rho_prev=rho_prev, time=time)
+
+        inverse_diagonal!(rD, U_eqn, config)
+        interpolate!(rDf, rD, config)
+
+        remove_pressure_source!(U_eqn, ∇p_rgh, config)
+
+        rp = 0.0
+        for i ∈ 1:inner_loops
+            H!(Hv, U, U_eqn, config)
+
+            interpolate!(Uf, Hv, config)
+            correct_boundaries!(Uf, Hv, boundaries.U, time, config)
+
+            flux!(mdotf, Uf, config)
+
+            phi_gf!(phi_gf, rho, ghf, rDf, model, config)
+
+            if typeof(mp_model) <: VOF
+                surface_tension_flux!(rDf, sigma, kappaf, alpha, phi_gf, config)
+            end
+
+            reconstruct!(phi_g, phi_gf, config)
+
+            @. mdotf.values += phi_gf.values
+
+            div!(divHv, mdotf, config)
+
+            @. prev = p_rgh.values
+            rp = solve_equation!(p_eqn, p_rgh, boundaries.p_rgh, solvers.p_rgh,
+                                 config; ref=pref, time=time)
+
+            grad!(∇p_rgh, p_rghf, p_rgh, boundaries.p_rgh, time, config)
+            limit_gradient!(schemes.p_rgh.limiter, ∇p_rgh, p_rgh, config)
+
+            correct_mass_flux!(mdotf, p_eqn, config)
+
+            pressure_grad!(p_rgh, ∇p_rghf_deconstructed, phi_gf, rDf, config)
+            reconstruct!(∇p_rghf_reconstructed, ∇p_rghf_deconstructed, config)
+
+            correct_velocity_rgh!(U, Hv, ∇p_rghf_reconstructed, rD, config)
+        end
+
+        @. p.values = p_rgh.values + (rho.values * gh.values)
+
+        turbulence!(turbulenceModel, model, S, prev, time, config)
+        update_nueff!(nueff, nuf, model.turbulence, config)
+        @. mueff.values = rhof.values * nueff.values
+
+        courant      = max_courant_number!(cellsCourant, model, config)
+        alphaCourant = max_alpha_courant_number!(cellsAlphaCourant, alpha, mdotf, model, config, dt_cpu[1])
+        update_dt!(config.runtime, courant, alphaCourant)
+
+        R_ux[iteration]    = rx
+        R_uy[iteration]    = ry
+        R_uz[iteration]    = rz
+        R_p[iteration]     = rp
+        R_alpha[iteration] = ralpha
+
+        ProgressMeter.next!(
+            progress, showvalues = [
+                (:dt, dt_cpu[1]),
+                (:time, time),
+                (:Courant, courant),
+                (:AlphaCourant, alphaCourant),
+                (:Ux, R_ux[iteration]),
+                (:Uy, R_uy[iteration]),
+                (:Uz, R_uz[iteration]),
+                (:p_rgh, R_p[iteration]),
+                (:alpha, R_alpha[iteration]),
+                turbulenceModel.state.residuals...
+                ]
+            )
+
+        runtime_postprocessing!(postprocess,iteration,iterations,S,time,config)
+
+        if iteration % write_interval + signbit(write_interval) == 0
+            save_output(model, outputWriter, iteration, time, config)
+            save_postprocessing(postprocess, iteration, time, mesh, outputWriter, config.boundaries)
+        end
+    end
+
+    return (Ux=R_ux, Uy=R_uy, Uz=R_uz, p=R_p, alpha=R_alpha)
+end
+
+
+
+function advance_alpha!(model, mp_model, ∇alpha, ∇alphaf, mdotf,
+                        alpha_prev, alphaf_upwind, alphaf_HO, phirf, phiLf, phiHf, phiAf,
+                        alpha_fluxf, div_alpha, div_mdotf,
+                        Pplus, Pminus, Qplus, Qminus, Rplus, Rminus,
+                        alphaMaxLocal, alphaMinLocal, C_alpha, dt, time, config)
+    (; alpha, alphaf) = model.fluid
+    (; schemes, boundaries) = config
+    mesh = model.domain
+
+    @. alpha_prev.values = alpha.values
+
+    grad!(∇alpha, alphaf, alpha, boundaries.alpha, time, config)
+    limit_gradient!(schemes.alpha.limiter, ∇alpha, alpha, config)
+
+    if typeof(mp_model) <: VOF
+        interpolate!(∇alphaf, ∇alpha.result, config)
+        compression_flux!(phirf, ∇alphaf, mdotf, C_alpha, config)
+    end
+
+    interpolate_upwind!(alphaf_upwind, alpha, mdotf, config)
+    correct_boundaries!(alphaf_upwind, alpha, boundaries.alpha, time, config)
+    interpolate_vanleer!(alphaf_HO, alpha, ∇alpha, mdotf, config)
+    correct_boundaries!(alphaf_HO, alpha, boundaries.alpha, time, config)
+
+    @. phiLf.values = mdotf.values * alphaf_upwind.values
+    @. phiHf.values = mdotf.values * alphaf_HO.values +
+                        phirf.values * alphaf_HO.values *
+                        (1.0 - alphaf_HO.values)
+    @. phiAf.values = phiHf.values - phiLf.values
+
+    zero_boundary_faces!(phiAf, config)
+
+    mules_limit!(mp_model,
+                 phiAf, alpha_prev, phiLf,
+                 Pplus, Pminus, Qplus, Qminus, Rplus, Rminus,
+                 alphaMaxLocal, alphaMinLocal,
+                 dt, mesh, config)
+
+    @. alpha_fluxf.values = phiLf.values + phiAf.values
+    div!(div_alpha, alpha_fluxf, config)
+    div!(div_mdotf, mdotf, config)
+    @. alpha.values = alpha_prev.values -
+        dt * (div_alpha.values - alpha_prev.values * div_mdotf.values)
+
+    interpolate_vanleer!(alphaf, alpha, ∇alpha, mdotf, config)
+    correct_boundaries!(alphaf, alpha, boundaries.alpha, time, config)
+    return nothing
+end
+
+
+
+function update_mixture_properties!(model, alpha_fluxf, mdotf, rhoPhi, nueff, mueff,
+                                    rho1_val, rho2_val, mu1_val, mu2_val, config)
+    (; rho, rhof, nu, nuf, alpha, alphaf) = model.fluid
+    blend_properties!(rho,  alpha,  rho1_val, rho2_val)
+    blend_properties!(rhof, alphaf, rho1_val, rho2_val)
+    blend_mixture_nu!(nu,  alpha,  rho,  mu1_val, mu2_val)
+    blend_mixture_nu!(nuf, alphaf, rhof, mu1_val, mu2_val)
+
+    @. mueff.values  = rhof.values * nueff.values
+    @. rhoPhi.values = alpha_fluxf.values * (rho1_val - rho2_val) +
+                        mdotf.values * rho2_val ### comment
+    return nothing
+end
+
+
+
+function update_curvature!(model, ∇alpha, ∇alphaf, nhatf_prep, kappa, kappaf,
+                           grad_alpha_mag, time, config)
+    (; alpha, alphaf) = model.fluid
+    (; schemes, boundaries) = config
+    grad!(∇alpha, alphaf, alpha, boundaries.alpha, time, config)
+    limit_gradient!(schemes.alpha.limiter, ∇alpha, alpha, config)
+    interpolate!(∇alphaf, ∇alpha.result, config)
+    nhat_prep!(nhatf_prep, alpha, ∇alphaf, config)
+    div!(kappa, nhatf_prep, config)
+    cell_grad_magnitude!(grad_alpha_mag, ∇alpha, config)
+    interpolate_weighted!(kappaf, kappa, grad_alpha_mag, config)
+    return nothing
+end
+
+
+"""
+    blend_properties!(property_field, alpha_field, property_0, property_1)
+
+Linearly blends a per-phase scalar property using the volume-fraction field:
+
+    property_field = property_0 * alpha + property_1 * (1 - alpha)
+"""
+function blend_properties!(property_field, alpha_field, property_0, property_1)
+    @. property_field.values = (property_0 * alpha_field.values) + (property_1 * (1.0 - alpha_field.values))
+    nothing
+end
+
+"""
+    blend_mixture_nu!(nu_field, alpha_field, rho_field, mu_0, mu_1)
+
+Mixture kinematic viscosity built from dynamic viscosity field:
+
+    nu = (mu_0 * alpha + mu_1 * (1 - alpha)) / rho_blend
+"""
+function blend_mixture_nu!(nu_field, alpha_field, rho_field, mu_0, mu_1)
+    @. nu_field.values = (mu_0 * alpha_field.values + mu_1 * (1.0 - alpha_field.values)) / rho_field.values
+    nothing
+end
+
+
+"""
+    compute_gh!(gh, g, config)
+
+Computes `g . x` at cell centres. Used for hydrostatic pressure reconstruction.
+"""
+function compute_gh!(gh, g, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    cells = gh.mesh.cells
+
+    ndrange = length(gh)
+    kernel! = _compute_gh!(_setup(backend, workgroup, ndrange)...)
+    kernel!(gh, g, cells)
+end
+@kernel inbounds=true function _compute_gh!(gh, g, cells)
+    i = @index(Global)
+    (; centre) = cells[i]
+    gh[i] = (g ⋅ centre)
+end
+
+
+"""
+    compute_ghf!(ghf, g, config)
+
+Computes `g . x` at face centres.
+"""
+function compute_ghf!(ghf, g, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    faces = ghf.mesh.faces
+
+    ndrange = length(ghf)
+    kernel! = _compute_ghf!(_setup(backend, workgroup, ndrange)...)
+    kernel!(ghf, g, faces)
+end
+@kernel inbounds=true function _compute_ghf!(ghf, g, faces)
+    i = @index(Global)
+    (; centre) = faces[i]
+    ghf[i] = (g ⋅ centre)
+end
+
+
+
+"""
+    phi_gf!(phi_gf, rho, ghf, rDf, model, config)
+
+Builds the gravity (buoyancy) contribution to the face mass flux. On each
+face computes
+
+    phi_gf[f] = -ghf[f] · area · snGrad(rho) · rDf[f]
+
+It is summed into `mdotf` before the pressure solve and reconstructed to
+a cell vector (`phi_g`) for the velocity correction. A face with 
+no density jump (single-phase region) contributes zero.
+"""
+function phi_gf!(phi_gf, rho, ghf, rDf, model, config)
+    (; faces, cells, boundary_cellsID) = model.domain
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+
+    n_bfaces = length(boundary_cellsID)
+
+    ndrange = length(faces)
+    kernel! = _phi_gf!(_setup(backend, workgroup, ndrange)...)
+    kernel!(phi_gf, rho, ghf, rDf, faces, cells, n_bfaces)
+end
+@kernel function _phi_gf!(phi_gf, rho, ghf, rDf, faces, cells, n_bfaces)
+    fID = @index(Global)
+    @inbounds begin
+        face = faces[fID]
+        (; area, normal, ownerCells, delta) = face
+        cID1 = ownerCells[1]
+        cID2 = ownerCells[2]
+        rho1 = rho[cID1]
+        rho2 = rho[cID2]
+
+        face_grad = area * (rho2 - rho1) / delta
+
+        phi_gf[fID] = -ghf[fID] * face_grad * rDf[fID]
+    end
+end
+
+"""
+    pressure_grad!(p_rgh, ∇p_rghf_deconstructed, phi_gf, rDf, config)
+
+Builds the face-normal pressure-gradient field used to correct the cell
+velocity (Rhie-Chow consistent). On each face computes
+
+    ∇p_rghf_deconstructed[f] = (phi_gf[f] - snGrad(p_rgh)·area·rDf[f]) / (rDf[f])
+
+The result is a face scalar later reconstructed to a cell vector (`reconstruct!`) 
+and fed to `correct_velocity_rgh!`.
+"""
+function pressure_grad!(p_rgh, ∇p_rghf_deconstructed, phi_gf, rDf, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    faces = ∇p_rghf_deconstructed.mesh.faces
+
+    ndrange = length(∇p_rghf_deconstructed)
+    kernel! = _pressure_grad!(_setup(backend, workgroup, ndrange)...)
+    kernel!(p_rgh, ∇p_rghf_deconstructed, phi_gf, rDf, faces)
+end
+@kernel function _pressure_grad!(p_rgh, ∇p_rghf_deconstructed, phi_gf, rDf, faces)
+    i = @index(Global)
+    face = faces[i]
+    (; area, normal, ownerCells, delta) = face
+
+    cID1 = ownerCells[1]
+    cID2 = ownerCells[2]
+    p1 = p_rgh[cID1]
+    p2 = p_rgh[cID2]
+    face_grad = area * (p2 - p1) / delta
+
+    ∇p_rghf_deconstructed[i] = (phi_gf[i] - (face_grad * rDf[i])) / (rDf[i] + eps())
+end
+
+"""
+    correct_velocity_rgh!(U, Hv, ∇p, rD, config)
+
+Slightly modified version of `correct_velocity!` for convenience.
+"""
+function correct_velocity_rgh!(U, Hv, ∇p, rD, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+
+    ndrange = length(U)
+    kernel! = _correct_velocity_rgh!(_setup(backend, workgroup, ndrange)...)
+    kernel!(U, Hv, ∇p, rD)
+end
+@kernel function _correct_velocity_rgh!(U, Hv, ∇p, rD)
+    i = @index(Global)
+
+    @uniform begin
+        Ux, Uy, Uz = U.x, U.y, U.z
+        Hvx, Hvy, Hvz = Hv.x, Hv.y, Hv.z
+        dpdx, dpdy, dpdz = ∇p.x, ∇p.y, ∇p.z
+        rDvalues = rD.values
+    end
+
+    @inbounds begin
+        rDvalues_i = rDvalues[i]
+        Ux[i] = Hvx[i] + dpdx[i] * rDvalues_i
+        Uy[i] = Hvy[i] + dpdy[i] * rDvalues_i
+        Uz[i] = Hvz[i] + dpdz[i] * rDvalues_i
+    end
+end
+
+"""
+    reconstruct!(phi::VectorField, psif::FaceScalarField, config)
+
+Least-squares reconstruction of a cell-centred vector field `phi` from a
+face-normal scalar field `psif`. Required for discretisation consistency.
+
+"""
+function reconstruct!(phi::VectorField, psif::FaceScalarField, config)
+    mesh = phi.mesh
+    (; cells, cell_nsign, cell_faces, faces) = mesh
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+
+    F = _get_float(mesh)
+    ndrange = length(cells)
+
+    if typeof(mesh) <: Mesh2
+        kernel! = _reconstruct_operation_2D!(_setup(backend, workgroup, ndrange)...)
+    else
+        kernel! = _reconstruct_operation_3D!(_setup(backend, workgroup, ndrange)...)
+    end
+    kernel!(cells, F, cell_faces, cell_nsign, faces, phi, psif)
+end
+
+@kernel function _reconstruct_operation_2D!(
+    cells::AbstractArray{Cell{TF,SV,UR}}, F, cell_faces, cell_nsign, faces, phi, psif
+) where {TF,SV,UR}
+    i = @index(Global)
+    @inbounds begin
+        (; faces_range) = cells[i]
+
+        m11 = zero(TF); m12 = zero(TF); m22 = zero(TF)
+        b1  = zero(TF); b2  = zero(TF)
+
+        for fi ∈ faces_range
+            fID = cell_faces[fi]
+            (; area, normal) = faces[fID]
+            nx = normal[1]; ny = normal[2]
+
+            m11 += area * nx * nx
+            m12 += area * nx * ny
+            m22 += area * ny * ny
+
+            ssf = psif[fID]
+            b1 += nx * ssf
+            b2 += ny * ssf
+        end
+
+        det = m11*m22 - m12*m12
+
+        is_invertible = abs(det) > eps(TF)
+        invdet = is_invertible ? one(TF)/det : zero(TF)
+
+        ux = ( m22*b1 - m12*b2) * invdet
+        uy = (-m12*b1 + m11*b2) * invdet
+
+        phi[i] = @SVector [ux, uy, zero(TF)]
+    end
+end
+
+@kernel function _reconstruct_operation_3D!(
+    cells::AbstractArray{Cell{TF,SV,UR}}, F, cell_faces, cell_nsign, faces, phi, psif
+) where {TF,SV,UR}
+    i = @index(Global)
+    @inbounds begin
+        (; faces_range) = cells[i]
+
+        m11 = zero(TF); m12 = zero(TF); m13 = zero(TF)
+                        m22 = zero(TF); m23 = zero(TF)
+                                        m33 = zero(TF)
+        b1 = zero(TF);  b2 = zero(TF);  b3 = zero(TF)
+
+        for fi ∈ faces_range
+            fID = cell_faces[fi]
+            (; area, normal) = faces[fID]
+            nx = normal[1]; ny = normal[2]; nz = normal[3]
+
+            m11 += area * nx * nx
+            m12 += area * nx * ny
+            m13 += area * nx * nz
+            m22 += area * ny * ny
+            m23 += area * ny * nz
+            m33 += area * nz * nz
+
+            ssf = psif[fID]
+            b1 += nx * ssf
+            b2 += ny * ssf
+            b3 += nz * ssf
+        end
+
+        A11 = m22*m33 - m23*m23
+        A12 = m13*m23 - m12*m33
+        A13 = m12*m23 - m13*m22
+
+        det = m11*A11 + m12*A12 + m13*A13
+
+        is_invertible = abs(det) > eps(TF)
+        invdet = is_invertible ? one(TF)/det : zero(TF)
+
+        ux = (A11*b1 + A12*b2 + A13*b3) * invdet
+        uy = (A12*b1 + (m11*m33 - m13*m13)*b2 + (m13*m12 - m11*m23)*b3) * invdet
+        uz = (A13*b1 + (m13*m12 - m11*m23)*b2 + (m11*m22 - m12*m12)*b3) * invdet
+
+        phi[i] = @SVector [ux, uy, uz]
+    end
+end
+
+
+# Removes boundary-related problems, required for mass conservation in some cases.
+function zero_boundary_faces!(phif::FaceScalarField, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    mesh = phif.mesh
+    nbfaces = length(mesh.boundary_cellsID)
+    if nbfaces > 0
+        ndrange = nbfaces
+        kernel! = _mmp_zero_boundary_faces!(_setup(backend, workgroup, ndrange)...)
+        kernel!(phif)
+    end
+end
+@kernel inbounds=true function _mmp_zero_boundary_faces!(phif)
+    i = @index(Global)
+    phif[i] = zero(eltype(phif.values))
+end
+
+
+"""
+    mules_limit!(mp_model::AbstractMultiphaseModel,
+                 phiAf, alpha_prev, phiLf,
+                 Pplus, Pminus, Qplus, Qminus, Rplus, Rminus,
+                 alphaMaxLocal, alphaMinLocal,
+                 dt, mesh, config)
+
+Unified MULES (Zalesak FCT) flux-limiter for explicit alpha transport, shared by
+both `VOF` and `Mixture` sub models. Limits the anti-diffusive
+face flux `phiAf = phiHf - phiLf` so the explicit update
+`α^{n+1} = α^n - dt/V · div(phiLf + phiAf)` stays bounded.
+
+Logic:
+
+  1. `mules_set_bounds!`: sets per-cell `alphaMax`, `alphaMin`
+      Dispatched:
+        - `VOF`     local neighbour extrema of `alpha_prev` between [0,1];
+                    prevents isolated alpha=1 cells; preserves sharp interface.
+        - `Mixture` hard `[0,1]` limit; must tolerate uniform alpha
+                                without freezing the anti-diffusive drift flux.
+  2. Build low-order α*, P+-, Q+-
+  3. Ratios: R+- = clamp(Q+-/P+-, 0, 1).
+  4. Per-face apply lambda_f (scales phiAf).
+
+Boundary faces are left unlimited (lambda = 1).
+"""
+function mules_limit!(mp_model::AbstractMultiphaseModel,
+                      phiAf, alpha_prev, phiLf,
+                      Pplus, Pminus, Qplus, Qminus, Rplus, Rminus,
+                      alphaMaxLocal, alphaMinLocal,
+                      dt, mesh, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    (; cells, cell_nsign, cell_faces, faces) = mesh
+
+    n_cells  = length(cells)
+    n_faces  = length(faces)
+    nbfaces  = length(mesh.boundary_cellsID)
+
+    fill!(Pplus.values,  0)
+    fill!(Pminus.values, 0)
+
+    # Required to prevent isolated alpha=1 cells
+    mules_set_bounds!(mp_model, alphaMaxLocal, alphaMinLocal, alpha_prev, mesh, config)
+
+    # Numerical consistency
+    ndrange = n_cells
+    kernel! = _mmp_mules_cell_accum!(_setup(backend, workgroup, ndrange)...)
+    kernel!(cells, cell_faces, cell_nsign, faces,
+            alpha_prev, phiLf, phiAf,
+            Pplus, Pminus, Qplus, Qminus,
+            alphaMaxLocal, alphaMinLocal, dt)
+
+    ndrange = n_cells
+    kernel! = _mmp_mules_ratios!(_setup(backend, workgroup, ndrange)...)
+    kernel!(Pplus, Pminus, Qplus, Qminus, Rplus, Rminus)
+
+    # Core MULES operation (compute phi contribution bounded by lambda)
+    ndrange = n_faces
+    kernel! = _mmp_mules_apply!(_setup(backend, workgroup, ndrange)...)
+    kernel!(phiAf, faces, Rplus, Rminus, nbfaces)
+end
+
+function mules_set_bounds!(::Mixture, alphaMaxLocal, alphaMinLocal, alpha_prev, mesh, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+
+    ndrange = length(mesh.cells)
+    kernel! = _mmp_mules_hard_bounds!(_setup(backend, workgroup, ndrange)...)
+    kernel!(alphaMaxLocal, alphaMinLocal)
+end
+
+function mules_set_bounds!(::VOF, alphaMaxLocal, alphaMinLocal, alpha_prev, mesh, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    (; cells, cell_faces, faces) = mesh
+
+    ndrange = length(cells)
+    kernel! = _mmp_mules_stencil_bounds!(_setup(backend, workgroup, ndrange)...)
+    kernel!(cells, cell_faces, faces, alpha_prev, alphaMaxLocal, alphaMinLocal)
+end
+
+@kernel inbounds=true function _mmp_mules_hard_bounds!(alphaMaxLocal, alphaMinLocal)
+    i = @index(Global)
+    TF = eltype(alphaMaxLocal.values)
+    alphaMaxLocal[i] = one(TF)
+    alphaMinLocal[i] = zero(TF)
+end
+
+@kernel inbounds=true function _mmp_mules_stencil_bounds!(
+    cells::AbstractArray{Cell{TF,SV,UR}}, cell_faces, faces,
+    alpha_prev, alphaMaxLocal, alphaMinLocal
+) where {TF,SV,UR}
+    i = @index(Global)
+    (; faces_range) = cells[i]
+
+    aMax = alpha_prev[i]
+    aMin = alpha_prev[i]
+
+    for fi in faces_range
+        fID = cell_faces[fi]
+        oc = faces[fID].ownerCells
+
+        j = ifelse(oc[1] == i, oc[2], oc[1])
+
+        aj = alpha_prev[j]
+        aMax = max(aMax, aj)
+        aMin = min(aMin, aj)
+    end
+
+    alphaMaxLocal[i] = min(one(TF),  aMax)
+    alphaMinLocal[i] = max(zero(TF), aMin)
+end
+
+@kernel inbounds=true function _mmp_mules_cell_accum!(
+    cells::AbstractArray{Cell{TF,SV,UR}}, cell_faces, cell_nsign, faces,
+    alpha_prev, phiLf, phiAf, Pplus, Pminus, Qplus, Qminus,
+    alphaMaxLocal, alphaMinLocal, dt
+) where {TF,SV,UR}
+    i = @index(Global)
+    (; volume, faces_range) = cells[i]
+
+    sum_L = zero(TF)
+    sum_A_pos = zero(TF)
+    sum_A_neg = zero(TF)
+
+    for fi in faces_range
+        fID   = cell_faces[fi]
+        nsign = cell_nsign[fi]
+
+        fL = phiLf[fID] * nsign
+        fA = phiAf[fID] * nsign
+        sum_L += fL
+
+        if fA < zero(TF)
+            sum_A_pos += -fA
+        else
+            sum_A_neg += fA
+        end
+    end
+
+    alpha_star = alpha_prev[i] - dt / volume * sum_L
+
+    Pplus[i]  = sum_A_pos
+    Pminus[i] = sum_A_neg
+
+    Qplus[i]  = max(zero(TF), (alphaMaxLocal[i] - alpha_star)) * volume / dt
+    Qminus[i] = max(zero(TF), (alpha_star - alphaMinLocal[i])) * volume / dt
+end
+
+@kernel inbounds=true function _mmp_mules_ratios!(Pplus, Pminus, Qplus, Qminus, Rplus, Rminus)
+    i = @index(Global)
+    TF = eltype(Pplus.values)
+
+    Pp = Pplus[i]; Pm = Pminus[i]
+    Qp = Qplus[i]; Qm = Qminus[i]
+
+    Rplus[i]  = Pp > eps(TF) ? clamp(Qp / Pp, zero(TF), one(TF)) : one(TF)
+    Rminus[i] = Pm > eps(TF) ? clamp(Qm / Pm, zero(TF), one(TF)) : one(TF)
+end
+
+@kernel inbounds=true function _mmp_mules_apply!(phiAf, faces, Rplus, Rminus, nbfaces)
+    i = @index(Global)
+    TF = eltype(phiAf.values)
+    if i > nbfaces
+        face = faces[i]
+        (; ownerCells) = face
+        cID1 = ownerCells[1]
+        cID2 = ownerCells[2]
+    
+        fA = phiAf[i]
+
+        lambda = if fA > zero(TF)
+            min(Rplus[cID2], Rminus[cID1])
+        elseif fA < zero(TF)
+            min(Rplus[cID1], Rminus[cID2])
+        else
+            one(TF)
+        end
+
+        phiAf[i] = lambda * fA
+    end
+end
+
+
+"""
+    compression_flux!(phirf, ∇alphaf, mdotf, C_alpha, config)
+
+Anti-diffusive compression face flux:
+
+    phir_f · Sf = min(Cα · |phi_f|/|Sf|, Phi_max) · (nnhatf · Sf)
+"""
+function compression_flux!(phirf, ∇alphaf, mdotf, C_alpha, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    mesh  = phirf.mesh
+    faces = mesh.faces
+    TF = _get_float(mesh)
+
+    # Phi max limits compression flux for numerical stability, compute it separately:
+    phi_over_S_buf = similar(mdotf.values)
+    ndrange = length(faces)
+    kernel! = _fill_phi_over_S!(_setup(backend, workgroup, ndrange)...)
+    kernel!(phi_over_S_buf, mdotf, faces)
+    phimax = maximum(phi_over_S_buf)
+
+    ndrange = length(faces)
+    kernel! = _compression_flux!(_setup(backend, workgroup, ndrange)...)
+    kernel!(phirf, ∇alphaf, mdotf, faces, TF(C_alpha), TF(phimax))
+end
+
+@kernel inbounds=true function _fill_phi_over_S!(buf, mdotf, faces)
+    i = @index(Global)
+    TF = eltype(buf)
+    area = faces[i].area
+    buf[i] = abs(mdotf[i]) / (area + eps(TF))
+end
+
+@kernel inbounds=true function _compression_flux!(phirf, ∇alphaf, mdotf, faces, C_alpha, phimax)
+    i = @index(Global)
+    face = faces[i]
+    (; area, normal, delta) = face
+    TF = eltype(phirf.values)
+
+    Sf = area * normal
+    grad_alpha     = ∇alphaf[i]
+    grad_alpha_mag = norm(grad_alpha)
+
+    noise_floor = TF(1.0e-8) / delta
+
+    if grad_alpha_mag > noise_floor
+        nhat = grad_alpha / grad_alpha_mag
+    else
+        nhat = zero(grad_alpha)
+    end
+
+    phi_over_S = abs(mdotf[i]) / (area + eps(TF))
+    compr_speed = min(C_alpha * phi_over_S, phimax)
+
+    phirf[i] = compr_speed * (nhat ⋅ Sf)
+end
+
+"""
+    cell_grad_magnitude!(mag_field, grad, config)
+
+Cell-centred `|∇alpha|` from a gradient field, used as the |∇alpha|-weighted face
+interpolation weight for kappa_f so that near wall cells with small |∇alpha| don't
+ruin the surface-tension force.
+"""
+function cell_grad_magnitude!(mag_field, grad, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    mesh = mag_field.mesh
+    ndrange = length(mesh.cells)
+    kernel! = _cell_grad_magnitude!(_setup(backend, workgroup, ndrange)...)
+    kernel!(mag_field, grad.result)
+end
+
+@kernel inbounds=true function _cell_grad_magnitude!(mag_field, grad_result)
+    i = @index(Global)
+    mag_field.values[i] = norm(grad_result[i])
+end
+
+"""
+    interpolate_weighted!(phif, phi, weight_field, config)
+
+Weighted face interpolation: `phif[f] = (phi_c1·w_c1 + phi_c2·w_c2) /
+(w_c1 + w_c2)`. With `w = |∇alpha|` it preserves kappa_f at interfaces and zeros
+it in bulk where kappa is noisy.
+"""
+function interpolate_weighted!(phif::FaceScalarField, phi::ScalarField,
+                                 weight_field::ScalarField, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    mesh = phif.mesh
+    (; faces) = mesh
+
+    ndrange = length(faces)
+    kernel! = _interpolate_weighted!(_setup(backend, workgroup, ndrange)...)
+    kernel!(phif, phi, weight_field, faces)
+end
+
+@kernel inbounds=true function _interpolate_weighted!(phif, phi, w, faces)
+    i = @index(Global)
+    face = faces[i]
+    (; ownerCells) = face
+    c1 = ownerCells[1]
+    c2 = ownerCells[2]
+    TF = eltype(phif.values)
+
+    w1 = w.values[c1]
+    w2 = w.values[c2]
+    denom = w1 + w2 + eps(TF)
+    phif[i] = (phi.values[c1] * w1 + phi.values[c2] * w2) / denom
+end
+
+"""
+    nhat_prep!(nhatf_prep, alpha, ∇alphaf, config)
+
+Builds a face-normal unit vector field from the face-interpolated alpha grad.
+"""
+function nhat_prep!(nhatf_prep, alpha, ∇alphaf, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    mesh = alpha.mesh
+    faces = mesh.faces
+    nbfaces = length(mesh.boundary_cellsID)
+    nfaces  = length(faces)
+
+    if nbfaces > 0
+        kernel! = _nhat_zero_bfaces!(_setup(backend, workgroup, nbfaces)...)
+        kernel!(nhatf_prep)
+    end
+
+    ninternal = nfaces - nbfaces
+    if ninternal > 0
+        kernel! = _nhat_normalise_ifaces!(_setup(backend, workgroup, ninternal)...)
+        kernel!(nhatf_prep, faces, ∇alphaf, nbfaces)
+    end
+end
+
+@kernel inbounds=true function _nhat_zero_bfaces!(nhatf_prep)
+    i = @index(Global)
+    nhatf_prep[i] = SVector(0.0, 0.0, 0.0)
+end
+
+@kernel inbounds=true function _nhat_normalise_ifaces!(nhatf_prep, faces, ∇alphaf_, nbfaces)
+    i = @index(Global)
+    fID = i + nbfaces
+    face = faces[fID]
+    (; delta) = face
+
+    grad_alpha     = ∇alphaf_[fID]
+    grad_alpha_mag = norm(grad_alpha)
+
+    noise_floor = 1e-8 / delta
+    if grad_alpha_mag < noise_floor
+        nhatf_prep[fID] = SVector(0.0, 0.0, 0.0)
+    else
+        nhatf_prep[fID] = grad_alpha / grad_alpha_mag
+    end
+end
+
+"""
+    surface_tension_flux!(rDf, sigma, kappaf, alpha, phi_gf, config)
+
+CSF surface-tension contribution to the face flux:
+`phi_gf -= σ · κf · (∇αf · Sf) · rDf`.
+"""
+function surface_tension_flux!(rDf, sigma, kappaf, alpha, phi_gf, config)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    faces = phi_gf.mesh.faces
+
+    ndrange = length(phi_gf)
+    kernel! = _surface_tension_flux!(_setup(backend, workgroup, ndrange)...)
+    kernel!(rDf, sigma, kappaf, alpha, phi_gf, faces)
+end
+
+@kernel inbounds=true function _surface_tension_flux!(rDf, sigma, kappaf, alpha, phi_gf, faces)
+    i = @index(Global)
+    face = faces[i]
+    (; area, normal, ownerCells, delta) = face
+    Sf = area * normal
+
+    cID1 = ownerCells[1]
+    cID2 = ownerCells[2]
+    alpha1 = alpha[cID1]
+    alpha2 = alpha[cID2]
+
+    ∇alphaf_vec = normal * ((alpha2 - alpha1) / delta)
+
+    phi_gf[i] -= sigma * kappaf[i] * (∇alphaf_vec ⋅ Sf) * rDf[i]
+end
+
+"""
+    well_balanced_pressure_grad!(grad_field, face_buf, p_rgh, rho, ghf,
+                                  mesh, config; sigma=0, kappaf=nothing,
+                                  alpha=nothing)
+
+Overrides `grad_field.values` with a face-snGrad reconstruction of the predictor body force terms:
+
+    face_buf[f] = area_f · ( snGrad(p_rgh) + ghf · snGrad(rho) - sigma·kappaf · snGrad(alpha) )
+
+*Important for stability.
+"""
+function well_balanced_pressure_grad!(
+    grad_field, face_buf, p_rgh, rho, ghf, mesh, config;
+    sigma=zero(eltype(p_rgh.values)),
+    kappaf, alpha,
+)
+    (; hardware) = config
+    (; backend, workgroup) = hardware
+    faces = mesh.faces
+
+    ndrange = length(faces)
+    kernel! = _well_balanced_pressure_face!(_setup(backend, workgroup, ndrange)...)
+    kernel!(face_buf, p_rgh, rho, alpha, ghf, kappaf, sigma, faces)
+
+    reconstruct!(grad_field, face_buf, config)
+end
+
+@kernel inbounds=true function _well_balanced_pressure_face!(
+    face_buf, p_rgh, rho, alpha, ghf, kappaf, sigma, faces
+)
+    i = @index(Global)
+    face = faces[i]
+    (; area, ownerCells, delta) = face
+    c1 = ownerCells[1]
+    c2 = ownerCells[2]
+
+    snGrad_p   = (p_rgh[c2] - p_rgh[c1]) / delta
+    snGrad_rho = (rho[c2]   - rho[c1])   / delta
+    snGrad_a   = (alpha[c2] - alpha[c1]) / delta
+
+    face_buf[i] = area * (snGrad_p + ghf[i] * snGrad_rho - sigma * kappaf[i] * snGrad_a)
+end

--- a/test/0_TEST_CASES/2d_multiphase_gravity.jl
+++ b/test/0_TEST_CASES/2d_multiphase_gravity.jl
@@ -1,0 +1,128 @@
+# In this case, a column of water is generated in a rectangular domain.
+#       It is then displaced by gravity until it hits a wall and starts sloshing.
+#       The test verifies mass conservation and water redistrubution on the bottom wall.
+
+using XCALibre
+using Test
+
+scaling = 0.001
+
+grids_dir = pkgdir(XCALibre, "examples/0_GRIDS")
+grid = "quad40.unv"
+mesh_file = joinpath(grids_dir, grid)
+mesh = UNV2D_mesh(mesh_file, scale=scaling)
+
+backend = CPU(); workgroup = AutoTune()
+hardware = Hardware(backend=backend, workgroup=workgroup)
+mesh_dev = adapt(backend, mesh)
+
+noSlipVelocity = [0.0, 0.0, 0.0]
+
+gravity = Gravity([0.0, -9.81, 0.0])
+
+model = Physics(
+    time = Transient(),
+    fluid = Fluid{Multiphase}(
+        model = VOF(sigma=0.072, cAlpha=1.0),
+        phases = (
+            Phase(rho=1000.0, mu=1.0e-3),
+            Phase(rho=1.2,    mu=1.8e-5),
+        ),
+        gravity = gravity
+    ),
+    turbulence = RANS{Laminar}(),
+    energy = Energy{Isothermal}(),
+    domain = mesh_dev
+    )
+
+operating_pressure = 0.0
+
+BCs = assign(
+    region = mesh_dev,
+    (
+        U = [
+            Wall(:inlet, noSlipVelocity),
+            Wall(:outlet, noSlipVelocity),
+            Zerogradient(:top),
+            Wall(:bottom, noSlipVelocity),
+        ],
+        p_rgh = [
+            Zerogradient(:inlet),
+            Zerogradient(:outlet),
+            Zerogradient(:bottom),
+            Dirichlet(:top, 0.0),
+        ],
+        alpha = [
+            Zerogradient(:inlet),
+            Zerogradient(:outlet),
+            Zerogradient(:bottom),
+            Zerogradient(:top),
+        ]
+    )
+)
+
+schemes = (
+    U =     Schemes(time=Euler, divergence=Upwind, laplacian=Linear),
+    p =     Schemes(time=Euler, gradient=Gauss,    laplacian=Linear),
+    p_rgh = Schemes(time=Euler, gradient=Gauss,    laplacian=Linear),
+    alpha = Schemes(time=Euler, divergence=Upwind, laplacian=Linear),
+)
+
+solvers = (
+    U = SolverSetup(
+        solver      = Bicgstab(),
+        preconditioner = Jacobi(),
+        convergence = 1e-7,
+        relax       = 1.0,
+        rtol        = 0.0,
+        atol        = 1.0e-5
+    ),
+    p_rgh = SolverSetup(
+        solver      = Cg(),
+        preconditioner = Jacobi(),
+        convergence = 1e-7,
+        relax       = 1.0,
+        rtol        = 0.0,
+        atol        = 1.0e-5
+    ),
+    alpha = SolverSetup(
+        solver      = Bicgstab(),
+        preconditioner = Jacobi(),
+        convergence = 1e-7,
+        relax       = 1.0,
+        rtol        = 0.0,
+        atol        = 1.0e-5
+    )
+)
+
+runtime = Runtime(iterations=4000, time_step=1.0e-4, write_interval=500)
+config  = Configuration(solvers=solvers, schemes=schemes,
+                        runtime=runtime, hardware=hardware, boundaries=BCs)
+
+GC.gc()
+
+# Water column: bottom-left corner up to (0.3, 0.4) m
+min_corner_vec = [0.0, 0.0, -0.5]
+max_corner_vec = [0.3, 0.4,  0.5]
+
+initialise!(model.momentum.p, operating_pressure)
+initialise!(model.momentum.U, noSlipVelocity)
+initialise!(model.fluid.alpha, 0.0)
+setField_Box!(mesh=mesh, field=model.fluid.alpha, value=1.0,
+              min_corner=min_corner_vec, max_corner=max_corner_vec)
+
+
+# Total water volume before the solve
+cell_volumes = [c.volume for c ∈ mesh.cells]
+initial_water_volume = sum(model.fluid.alpha.values .* cell_volumes)
+
+residuals = run!(model, config)
+
+
+# 1) Mass conservation: total water volume must be unchanged
+final_water_volume = sum(model.fluid.alpha.values .* cell_volumes)
+@test final_water_volume ≈ initial_water_volume rtol=1e-7
+
+# 2) The collapsed column should cover the floor: bottom boundary is ~all water
+bottom_alpha = boundary_average(:bottom, model.fluid.alpha, BCs.alpha, config)
+@test bottom_alpha > 0.99

--- a/test/0_TEST_CASES/2d_multiphase_hydrostatic.jl
+++ b/test/0_TEST_CASES/2d_multiphase_hydrostatic.jl
@@ -1,0 +1,131 @@
+# In this case, a hydrostatic water-air column is initialised.
+#       After 10,000 iterations velocity currents must not develop if discretisation is consistent.
+#       *Note: test is currently reduced to 1,000 iterations to save time.
+
+
+using XCALibre
+using Test
+using LinearAlgebra
+
+scaling = 0.001 
+
+grids_dir = pkgdir(XCALibre, "examples/0_GRIDS")
+grid = "quad100.unv"
+mesh_file = joinpath(grids_dir, grid)
+mesh = UNV2D_mesh(mesh_file, scale=scaling)
+
+backend = CPU(); workgroup = AutoTune(); activate_multithread(backend)
+
+hardware = Hardware(backend=backend, workgroup=workgroup)
+mesh_dev = adapt(backend, mesh)
+
+noSlipVelocity = [0.0, 0.0, 0.0]
+
+gravity = Gravity([0.0, -9.81, 0.0])
+
+
+model = Physics(
+    time = Transient(),
+    fluid = Fluid{Multiphase}(
+        model = VOF(cAlpha=0.0, sigma=0.0),
+        phases = (
+            Phase(rho=1000.0, mu=1.0e-3),
+            Phase(rho=1.2,    mu=1.8e-5),
+        ),
+        gravity = gravity
+    ),
+    turbulence = RANS{Laminar}(),
+    energy = Energy{Isothermal}(),
+    domain = mesh_dev
+    )
+
+operating_pressure = 0.0
+
+
+BCs = assign(
+    region = mesh_dev,
+    (
+        U = [
+            Wall(:inlet, noSlipVelocity),
+            Wall(:outlet, noSlipVelocity),
+            Extrapolated(:top), 
+            Wall(:bottom, noSlipVelocity),
+        ],
+        p_rgh = [
+            Zerogradient(:inlet),
+            Zerogradient(:outlet),
+            Zerogradient(:bottom),
+            # Zerogradient(:top),
+            Dirichlet(:top, 0.0),
+        ],
+        alpha = [
+            Zerogradient(:inlet),
+            Zerogradient(:outlet),
+            Zerogradient(:bottom),
+            Extrapolated(:top),
+        ]
+    )
+)
+
+schemes = (
+    U =     Schemes(time=Euler, divergence=Upwind, laplacian=Linear),
+    p =     Schemes(time=Euler, gradient=Gauss,    laplacian=Linear),
+    p_rgh = Schemes(time=Euler, gradient=Gauss,    laplacian=Linear),
+    alpha = Schemes(time=Euler, divergence=Upwind, laplacian=Linear),
+)
+
+solvers = (
+    U = SolverSetup(
+        solver      = Bicgstab(), # Bicgstab(), Gmres()
+        preconditioner = Jacobi(), # ILU0GPU, Jacobi, DILU
+        convergence = 1e-7,
+        relax       = 1.0,
+        rtol        = 0.0,
+        atol        = 1.0e-5
+    ),
+    p_rgh = SolverSetup(
+        solver      = Cg(), # Bicgstab(), Gmres(), Cg()
+        preconditioner = Jacobi(), # IC0GPU, Jacobi, DILU
+        convergence = 1e-7,
+        relax       = 1.0,
+        rtol        = 0.0,
+        atol        = 1.0e-7
+        
+    ),
+    alpha = SolverSetup(
+        solver      = Bicgstab(), # Bicgstab(), Gmres(), Cg()
+        preconditioner = Jacobi(), # IC0GPU, Jaco•bi, DILU
+        convergence = 1e-7,
+        relax       = 1.0,
+        rtol        = 0.0,
+        atol        = 1.0e-5
+    )
+)
+
+hardware = Hardware(backend=backend, workgroup=workgroup)
+
+min_corner_vec = [0.0, 0.0, -0.5]
+max_corner_vec = [1.0, 0.5,  0.5]
+
+runtime = Runtime(iterations=1000, time_step=1.0e-5, write_interval=20000)
+config  = Configuration(solvers=solvers, schemes=schemes,
+                        runtime=runtime, hardware=hardware, boundaries=BCs)
+
+GC.gc()
+
+min_corner_vec = [0.0, 0.0, -0.5]
+max_corner_vec = [1.0, 0.5,  0.5]
+
+initialise!(model.fluid.p_rgh, 0.0)
+initialise!(model.momentum.U, noSlipVelocity)
+initialise!(model.fluid.alpha, 0.0)
+setField_Box!(mesh=mesh, field=model.fluid.alpha, value=1.0,
+              min_corner=min_corner_vec, max_corner=max_corner_vec)
+
+
+residuals = run!(model, config)
+
+U = model.momentum.U
+vel_mag = sqrt.(U.x.values.^2 .+ U.y.values.^2 .+ U.z.values.^2)
+mean_vel_mag = sum(vel_mag) / length(vel_mag)
+@test mean_vel_mag < 1e-9

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,26 @@ TEST_CASES_DIR = pkgdir(XCALibre, "test/0_TEST_CASES")
         end
     end
 
+    @testset "Godunov Solver" begin
+        include(joinpath(TEST_CASES_DIR, "2d_godunov_supersonic_cylinder.jl"))
+    end
+
+    @testset "Multiphase Solver" begin
+        test_files = [
+            "2d_multiphase_gravity.jl",
+            "2d_multiphase_hydrostatic.jl"
+        ]
+
+        for test ∈ test_files
+            test_path = joinpath(TEST_CASES_DIR, test)
+            include(test_path)
+        end
+    end
+
+    @testset "Thin Film Solver" begin
+        include(joinpath(TEST_CASES_DIR, "2d_EFM.jl"))
+    end
+
     foreach(rm, filter(endswith(".vtk"), readdir(pwd(), join=true)))
     foreach(rm, filter(endswith(".vtu"), readdir(pwd(), join=true)))
 


### PR DESCRIPTION
- Added multiphase solver currently supporting VOF model. FCT-based MULES algorithm is used for phase fraction boundedness for explicit advancements.
- Adaptive time-stepping was updated to add maxAlphaCo, suitable for newly added solver.
- `Euler` and `Crank-Nicholson` time discretisation schemes were updated to be able to use `rho_prev` in momentum equation when needed.

- Added two functionality tests for the new solver:
> Hydrostatic column: verifies discretisation consistency under gravitational effects.
> Mini dam-break: verifies water (phase fraction field) advances correctly with time under gravitational effects.